### PR TITLE
Add JEI drag fluids to filters

### DIFF
--- a/src/main/java/com/direwolf20/laserio/client/jei/ghostfilterhandlers/GhostFilterCard.java
+++ b/src/main/java/com/direwolf20/laserio/client/jei/ghostfilterhandlers/GhostFilterCard.java
@@ -40,7 +40,7 @@ public class GhostFilterCard implements IGhostIngredientHandler<CardItemScreen> 
                         PacketHandler.sendToServer(new PacketGhostSlot(slot.index, itemStack, itemStack.getCount()));
                     }
                 });
-            } else if (ingredient instanceof FluidStack && (slot instanceof FilterBasicSlot)) {
+            } else if (ingredient.getIngredient() instanceof FluidStack && (slot instanceof FilterBasicSlot)) {
                 targets.add(new Target<I>() {
                     @Override
                     public Rect2i getArea() {


### PR DESCRIPTION
This appears to have been fixed in https://github.com/direwolf20-mc/LaserIO/commit/b7e2834bdba67888b651818d37bc529071991553 as part of porting to 1.20.6.

Fixes #25.