### PR TITLE
Improve containers and screens

### DIFF
--- a/src/main/java/com/direwolf20/laserio/client/screens/CardEnergyScreen.java
+++ b/src/main/java/com/direwolf20/laserio/client/screens/CardEnergyScreen.java
@@ -5,8 +5,11 @@ import com.direwolf20.laserio.client.screens.widgets.NumberButton;
 import com.direwolf20.laserio.client.screens.widgets.ToggleButton;
 import com.direwolf20.laserio.common.LaserIO;
 import com.direwolf20.laserio.common.containers.CardEnergyContainer;
+import com.direwolf20.laserio.common.containers.CardHolderContainer;
+import com.direwolf20.laserio.common.containers.customslot.CardHolderSlot;
 import com.direwolf20.laserio.common.containers.customslot.CardItemSlot;
 import com.direwolf20.laserio.common.containers.customslot.CardOverclockSlot;
+import com.direwolf20.laserio.common.items.CardHolder;
 import com.direwolf20.laserio.common.items.cards.BaseCard;
 import com.direwolf20.laserio.common.items.cards.CardEnergy;
 import com.direwolf20.laserio.common.items.cards.CardRedstone;
@@ -56,6 +59,7 @@ public class CardEnergyScreen extends AbstractContainerScreen<CardEnergyContaine
     protected final ItemStack card;
     protected Map<String, Button> buttons = new HashMap<>();
     protected byte currentRedstoneMode;
+    private boolean showCardHolderUI;
     protected ItemStack lastOverclocker;
 
     protected final String[] sneakyNames = {
@@ -72,6 +76,7 @@ public class CardEnergyScreen extends AbstractContainerScreen<CardEnergyContaine
         super(container, inv, name);
         this.container = container;
         this.card = container.cardItem;
+        this.showCardHolderUI = false;
     }
 
     @Override
@@ -81,6 +86,9 @@ public class CardEnergyScreen extends AbstractContainerScreen<CardEnergyContaine
 
     @Override
     public void render(GuiGraphics guiGraphics, int mouseX, int mouseY, float partialTicks) {
+        if (CardEnergyContainer.SLOTS == 1) {
+            validateHolder();
+        }
         this.renderBackground(guiGraphics);
         super.render(guiGraphics, mouseX, mouseY, partialTicks);
         this.renderTooltip(guiGraphics, mouseX, mouseY);
@@ -155,6 +163,40 @@ public class CardEnergyScreen extends AbstractContainerScreen<CardEnergyContaine
         if (MiscTools.inBounds(limitButton.getX(), limitButton.getY(), limitButton.getWidth(), limitButton.getHeight(), mouseX, mouseY)) {
             guiGraphics.renderTooltip(font, Component.translatable("screen.laserio.energylimit"), mouseX, mouseY);
         }
+    }
+
+    public boolean validateHolder() {
+        Inventory playerInventory = container.playerEntity.getInventory();
+        for (int i = 0; i < playerInventory.items.size(); i++) {
+            ItemStack itemStack = playerInventory.items.get(i);
+            if (itemStack.getItem() instanceof CardHolder) {
+                if (CardHolder.getUUID(itemStack).equals(container.cardHolderUUID)) {
+                    showCardHolderUI = true;
+                    toggleHolderSlots();
+                    return true;
+                }
+            }
+        }
+        showCardHolderUI = false;
+        toggleHolderSlots();
+        return false;
+    }
+
+    public void toggleHolderSlots() {
+        for (int i = CardEnergyContainer.SLOTS; i < (CardEnergyContainer.SLOTS + CardHolderContainer.SLOTS); i++) {
+            if (i >= container.slots.size()) continue;
+            Slot slot = container.getSlot(i);
+            if (!(slot instanceof CardHolderSlot)) continue;
+            ((CardHolderSlot) slot).setEnabled(showCardHolderUI);
+        }
+    }
+
+    @Override
+    protected boolean hasClickedOutside(double mouseX, double mouseY, int guiLeftIn, int guiTopIn, int mouseButton) {
+        if (showCardHolderUI) {
+            return mouseX < (double) guiLeftIn - 100 || mouseY < (double) guiTopIn || mouseX >= (double) (guiLeftIn + this.imageWidth) || mouseY >= (double) (guiTopIn + this.imageHeight);
+        }
+        return super.hasClickedOutside(mouseX, mouseY, guiLeftIn, guiTopIn, mouseButton);
     }
 
     public void addAmtButton() {
@@ -431,6 +473,11 @@ public class CardEnergyScreen extends AbstractContainerScreen<CardEnergyContaine
         int relX = (this.width - this.imageWidth) / 2;
         int relY = (this.height - this.imageHeight) / 2;
         guiGraphics.blit(GUI, relX, relY, 0, 0, this.imageWidth, this.imageHeight);
+        if (showCardHolderUI) {
+            ResourceLocation CardHolderGUI = new ResourceLocation(LaserIO.MODID, "textures/gui/cardholder_node.png");
+            RenderSystem.setShaderTexture(0, CardHolderGUI);
+            guiGraphics.blit(CardHolderGUI, getGuiLeft() - 100, getGuiTop() + 24, 0, 0, this.imageWidth, this.imageHeight);
+        }
     }
 
     @Override

--- a/src/main/java/com/direwolf20/laserio/client/screens/CardItemScreen.java
+++ b/src/main/java/com/direwolf20/laserio/client/screens/CardItemScreen.java
@@ -94,8 +94,8 @@ public class CardItemScreen extends AbstractContainerScreen<CardItemContainer> {
         super(container, inv, name);
         this.container = container;
         this.card = container.cardItem;
-        filter = container.slots.get(0).getItem();
-        showCardHolderUI = container.cardHolder.isEmpty();
+        this.filter = container.slots.get(0).getItem();
+        this.showCardHolderUI = container.cardHolder.isEmpty();
     }
 
     @Override
@@ -228,7 +228,7 @@ public class CardItemScreen extends AbstractContainerScreen<CardItemContainer> {
     }
 
     public void toggleHolderSlots() {
-        for (int i = 17; i < 17 + CardHolderContainer.SLOTS; i++) {
+        for (int i = (CardItemContainer.SLOTS + CardItemContainer.FILTERSLOTS); i < (CardItemContainer.SLOTS + CardItemContainer.FILTERSLOTS + CardHolderContainer.SLOTS); i++) {
             if (i >= container.slots.size()) continue;
             Slot slot = container.getSlot(i);
             if (!(slot instanceof CardHolderSlot)) continue;
@@ -238,8 +238,9 @@ public class CardItemScreen extends AbstractContainerScreen<CardItemContainer> {
 
     @Override
     protected boolean hasClickedOutside(double mouseX, double mouseY, int guiLeftIn, int guiTopIn, int mouseButton) {
-        if (showCardHolderUI)
+        if (showCardHolderUI) {
             return mouseX < (double) guiLeftIn - 100 || mouseY < (double) guiTopIn || mouseX >= (double) (guiLeftIn + this.imageWidth) || mouseY >= (double) (guiTopIn + this.imageHeight);
+        }
         return super.hasClickedOutside(mouseX, mouseY, guiLeftIn, guiTopIn, mouseButton);
     }
 
@@ -422,7 +423,6 @@ public class CardItemScreen extends AbstractContainerScreen<CardItemContainer> {
         if (!showNBT) removeWidget(buttons.get("nbt"));
         if (!showAllow) removeWidget(buttons.get("allowList"));
 
-
         if (card.getCount() > 1) {
             for (int i = 0; i < CardItemContainer.SLOTS; i++) {
                 if (i >= container.slots.size()) continue;
@@ -597,7 +597,7 @@ public class CardItemScreen extends AbstractContainerScreen<CardItemContainer> {
                 removeWidget(exactButton);
             }
         }
-        for (int i = CardItemContainer.SLOTS; i < CardItemContainer.SLOTS + CardItemContainer.FILTERSLOTS; i++) {
+        for (int i = CardItemContainer.SLOTS; i < (CardItemContainer.SLOTS + CardItemContainer.FILTERSLOTS); i++) {
             if (i >= container.slots.size()) continue;
             Slot slot = container.getSlot(i);
             if (!(slot instanceof FilterBasicSlot)) continue;
@@ -678,7 +678,6 @@ public class CardItemScreen extends AbstractContainerScreen<CardItemContainer> {
         InputConstants.Key mouseKey = InputConstants.getKey(p_keyPressed_1_, p_keyPressed_2_);
         if (p_keyPressed_1_ == 256 || minecraft.options.keyInventory.isActiveAndMatches(mouseKey)) {
             onClose();
-
             return true;
         }
         return super.keyPressed(p_keyPressed_1_, p_keyPressed_2_, p_keyPressed_3_);
@@ -712,8 +711,9 @@ public class CardItemScreen extends AbstractContainerScreen<CardItemContainer> {
     }
 
     public void saveSettings() {
-        if (showFilter)
+        if (showFilter) {
             PacketHandler.sendToServer(new PacketUpdateFilter(isAllowList == 1, isCompareNBT == 1));
+        }
         PacketHandler.sendToServer(new PacketUpdateCard(currentMode, currentChannel, currentItemExtractAmt, currentPriority, currentSneaky, (short) currentTicks, currentExact, currentRegulate, (byte) currentRoundRobin, 0, 0, currentRedstoneMode, currentRedstoneChannel, currentAndMode));
     }
 
@@ -781,7 +781,6 @@ public class CardItemScreen extends AbstractContainerScreen<CardItemContainer> {
             setExtract(amountButton, btn);
             return true;
         }
-
         NumberButton speedButton = ((NumberButton) buttons.get("speed"));
         if (MiscTools.inBounds(speedButton.getX(), speedButton.getY(), speedButton.getWidth(), speedButton.getHeight(), x, y)) {
             if (btn == 0)
@@ -816,7 +815,7 @@ public class CardItemScreen extends AbstractContainerScreen<CardItemContainer> {
             }
             return true;
         }
-        if (hoveredSlot instanceof CardItemSlot) { //Right click
+        if (hoveredSlot instanceof CardItemSlot) {
             if (btn == 0) {
                 if (filter.getItem() instanceof BaseFilter && !(filter.getItem() instanceof FilterTag) && !(filter.getItem() instanceof FilterNBT)) //Save the filter before removing it from the slot
                     PacketHandler.sendToServer(new PacketUpdateFilter(isAllowList == 1, isCompareNBT == 1));

--- a/src/main/java/com/direwolf20/laserio/common/containers/CardEnergyContainer.java
+++ b/src/main/java/com/direwolf20/laserio/common/containers/CardEnergyContainer.java
@@ -1,8 +1,12 @@
 package com.direwolf20.laserio.common.containers;
 
 import com.direwolf20.laserio.common.blockentities.LaserNodeBE;
+import com.direwolf20.laserio.common.blocks.LaserNode;
 import com.direwolf20.laserio.common.containers.customhandler.CardItemHandler;
+import com.direwolf20.laserio.common.containers.customslot.CardHolderSlot;
 import com.direwolf20.laserio.common.containers.customslot.CardOverclockSlot;
+import com.direwolf20.laserio.common.items.CardHolder;
+import com.direwolf20.laserio.common.items.cards.BaseCard;
 import com.direwolf20.laserio.common.items.cards.CardEnergy;
 import com.direwolf20.laserio.common.items.upgrades.OverclockerCard;
 import com.direwolf20.laserio.setup.Config;
@@ -15,15 +19,20 @@ import net.minecraft.world.inventory.AbstractContainerMenu;
 import net.minecraft.world.inventory.ClickType;
 import net.minecraft.world.inventory.MenuType;
 import net.minecraft.world.inventory.Slot;
+import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.entity.BlockEntity;
+import net.minecraftforge.common.capabilities.ForgeCapabilities;
 import net.minecraftforge.items.IItemHandler;
 import net.minecraftforge.items.ItemHandlerHelper;
+import net.minecraftforge.items.ItemStackHandler;
 import net.minecraftforge.items.SlotItemHandler;
 import net.minecraftforge.items.wrapper.InvWrapper;
 
 import javax.annotation.Nullable;
+
+import java.util.UUID;
 
 public class CardEnergyContainer extends AbstractContainerMenu {
     public static final int SLOTS = (Config.MAX_FE_TIERS.get().isEmpty()) ? 0 : 1;
@@ -33,6 +42,9 @@ public class CardEnergyContainer extends AbstractContainerMenu {
     protected IItemHandler playerInventory;
     public BlockPos sourceContainer = BlockPos.ZERO;
     public byte direction = -1;
+    public ItemStack cardHolder;
+    public IItemHandler cardHolderHandler;
+    public UUID cardHolderUUID;
 
     protected CardEnergyContainer(@Nullable MenuType<?> pMenuType, int pContainerId) {
         super(pMenuType, pContainerId);
@@ -41,17 +53,27 @@ public class CardEnergyContainer extends AbstractContainerMenu {
     public CardEnergyContainer(int windowId, Inventory playerInventory, Player player, FriendlyByteBuf extraData) {
         this(windowId, playerInventory, player, extraData.readItem());
         this.direction = extraData.readByte();
+        if (SLOTS == 1) {
+            this.cardHolder = LaserNode.findCardHolders(player);
+        }
     }
 
     public CardEnergyContainer(int windowId, Inventory playerInventory, Player player, ItemStack cardItem) {
         super(Registration.CardEnergy_Container.get(), windowId);
-        playerEntity = player;
-        if (SLOTS == 1)
+        this.playerEntity = player;
+        if (SLOTS == 1) {
             this.handler = CardEnergy.getInventory(cardItem);
+            this.cardHolder = LaserNode.findCardHolders(player);
+        }
         this.playerInventory = new InvWrapper(playerInventory);
         this.cardItem = cardItem;
         if (handler != null) {
             addSlotRange(handler, 0, 153, 5, 1, 18);
+        }
+        if (cardHolder != null && !cardHolder.isEmpty()) {
+            this.cardHolderHandler = cardHolder.getCapability(ForgeCapabilities.ITEM_HANDLER, null).orElse(new ItemStackHandler(CardHolderContainer.SLOTS));
+            addSlotBox(cardHolderHandler, 0, -92, 32, 5, 18, 3, 18);
+            cardHolderUUID = CardHolder.getUUID(cardHolder);
         }
         layoutPlayerInventorySlots(8, 84);
     }
@@ -64,41 +86,88 @@ public class CardEnergyContainer extends AbstractContainerMenu {
 
     @Override
     public void clicked(int slotId, int dragType, ClickType clickTypeIn, Player player) {
+        if (slotId >= 0) {
+            Slot slot = slots.get(slotId);
+            ItemStack stackInSlot = slot.getItem();
+            if (slot instanceof CardHolderSlot) {
+                ItemStack carriedItem = getCarried();
+                if (stackInSlot.getMaxStackSize() == 1 && stackInSlot.getCount() > 1) {
+                    if (!carriedItem.isEmpty() && !stackInSlot.isEmpty() && !ItemStack.isSameItemSameTags(carriedItem, stackInSlot)) {
+                        return;
+                    }
+                }
+            } else {
+                Item slotItem = stackInSlot.getItem();
+                if (slotItem instanceof BaseCard && stackInSlot == player.getMainHandItem() || slotItem instanceof CardHolder) {
+                    return;
+                }
+            }
+        }
         super.clicked(slotId, dragType, clickTypeIn, player);
     }
 
     @Override
     public boolean stillValid(Player playerIn) {
-        if (sourceContainer.equals(BlockPos.ZERO))
+        if (SLOTS == 1 && cardHolder.isEmpty() && cardHolderUUID != null) {
+            //System.out.println("Lost card holder!");
+            Inventory playerInventory = playerEntity.getInventory();
+            for (int i = 0; i < playerInventory.items.size(); i++) {
+                ItemStack itemStack = playerInventory.items.get(i);
+                if (itemStack.getItem() instanceof CardHolder) {
+                    if (CardHolder.getUUID(itemStack).equals(cardHolderUUID)) {
+                        cardHolder = itemStack;
+                        break;
+                    }
+                }
+            }
+        }
+        if (sourceContainer.equals(BlockPos.ZERO)) {
             return playerIn.getMainHandItem().equals(cardItem) || playerIn.getOffhandItem().equals(cardItem);
+        }
+        return true;
+    }
+
+    @Override
+    public boolean canTakeItemForPickAll(ItemStack itemStack, Slot slot) {
+        if (slot instanceof CardHolderSlot) {
+            return false;
+        }
         return true;
     }
 
     @Override
     public ItemStack quickMoveStack(Player playerIn, int index) {
-        if (cardItem.getCount() > 1) return ItemStack.EMPTY; // Don't let quickMove happen in multistack cards
-        ItemStack itemstack = ItemStack.EMPTY;
+        if (SLOTS == 0 || cardItem.getCount() > 1) return ItemStack.EMPTY; //Don't let quickMove happen in multistack cards or if Energy Overclockers are not defined
+        ItemStack itemStack = ItemStack.EMPTY;
         Slot slot = this.slots.get(index);
         if (slot != null && slot.hasItem()) {
             ItemStack stack = slot.getItem();
-            itemstack = stack.copy();
-            if (ItemHandlerHelper.canItemStacksStack(itemstack, cardItem)) return ItemStack.EMPTY;
+            itemStack = stack.copy();
+            if (ItemHandlerHelper.canItemStacksStack(itemStack, cardItem)) return ItemStack.EMPTY;
 
-            if (SLOTS == 1) {
-                if (index < SLOTS) {
+            if (index < SLOTS) {
+                if (!cardHolder.isEmpty()) { //Do the below set of logic if we have a card holder, otherwise just try to move to inventory
+                    if (!this.moveItemStackTo(stack, SLOTS, SLOTS + CardHolderContainer.SLOTS, false)) { //Try the CardHolder First!
+                        return ItemStack.EMPTY;
+                    }
+                    if (!this.moveItemStackTo(stack, SLOTS + CardHolderContainer.SLOTS, 36 + SLOTS + CardHolderContainer.SLOTS, true)) {
+                        return ItemStack.EMPTY;
+                    }
+                } else { //If no card holder, the slot targets are different
                     if (!this.moveItemStackTo(stack, SLOTS, 36 + SLOTS, true)) {
                         return ItemStack.EMPTY;
                     }
-                    slot.onQuickCraft(stack, itemstack);
-                } else { //From player inventory TO something
-                    ItemStack currentStack = slot.getItem().copy();
-                    if (slots.get(0).mayPlace(currentStack) && currentStack.getItem() instanceof OverclockerCard card && card.getEnergyTier() > 0) {
-                        if (!this.moveItemStackTo(stack, 0, SLOTS, false)) {
-                            return ItemStack.EMPTY;
-                        }
+                }
+                slot.onQuickCraft(stack, itemStack);
+            } else { //From player inventory (or Card Holder) TO something
+                ItemStack currentStack = slot.getItem().copy();
+                if (slots.get(0).mayPlace(currentStack) && currentStack.getItem() instanceof OverclockerCard card && card.getEnergyTier() > 0) {
+                    if (!this.moveItemStackTo(stack, 0, SLOTS, false)) {
+                        return ItemStack.EMPTY;
                     }
-                    if (!playerIn.level().isClientSide())
-                        CardEnergy.setInventory(cardItem, handler);
+                }
+                if (!playerIn.level().isClientSide()) {
+                    CardEnergy.setInventory(cardItem, handler);
                 }
             }
 
@@ -108,20 +177,21 @@ public class CardEnergyContainer extends AbstractContainerMenu {
                 slot.setChanged();
             }
 
-            if (stack.getCount() == itemstack.getCount()) {
+            if (stack.getCount() == itemStack.getCount()) {
                 return ItemStack.EMPTY;
             }
 
             slot.onTake(playerIn, stack);
         }
-
-        return itemstack;
+        return itemStack;
     }
 
     protected int addSlotRange(IItemHandler handler, int index, int x, int y, int amount, int dx) {
         for (int i = 0; i < amount; i++) {
             if (handler instanceof CardItemHandler && index == 0)
                 addSlot(new CardOverclockSlot(handler, index, x, y));
+            else if (handler != null && (handler.getSlots() == CardHolderContainer.SLOTS))
+                addSlot(new CardHolderSlot(handler, index, x, y));
             else
                 addSlot(new SlotItemHandler(handler, index, x, y));
             x += dx;

--- a/src/main/java/com/direwolf20/laserio/common/containers/CardHolderContainer.java
+++ b/src/main/java/com/direwolf20/laserio/common/containers/CardHolderContainer.java
@@ -1,6 +1,7 @@
 package com.direwolf20.laserio.common.containers;
 
 import com.direwolf20.laserio.common.containers.customslot.CardHolderSlot;
+import com.direwolf20.laserio.common.items.CardHolder;
 import com.direwolf20.laserio.setup.Registration;
 import net.minecraft.core.BlockPos;
 import net.minecraft.network.FriendlyByteBuf;
@@ -42,12 +43,18 @@ public class CardHolderContainer extends AbstractContainerMenu {
 
     @Override
     public void clicked(int slotId, int dragType, ClickType clickTypeIn, Player player) {
-        if (slotId >= 0 && slotId < SLOTS && slots.get(slotId) instanceof CardHolderSlot) {
-            ItemStack carriedItem = getCarried();
-            ItemStack stackInSlot = slots.get(slotId).getItem();
-            if (stackInSlot.getMaxStackSize() == 1 && stackInSlot.getCount() > 1) {
-                if (!carriedItem.isEmpty() && !stackInSlot.isEmpty() && !ItemStack.isSameItemSameTags(carriedItem, stackInSlot))
-                    return;
+        if (slotId >= 0) {
+            Slot slot = slots.get(slotId);
+            ItemStack stackInSlot = slot.getItem();
+            if (slotId < SLOTS && slot instanceof CardHolderSlot) {
+                if (stackInSlot.getMaxStackSize() == 1 && stackInSlot.getCount() > 1) {
+                    ItemStack carriedItem = getCarried();
+                    if (!carriedItem.isEmpty() && !stackInSlot.isEmpty() && !ItemStack.isSameItemSameTags(carriedItem, stackInSlot)) {
+                        return;
+                    }
+                }
+            } else if (stackInSlot.getItem() instanceof CardHolder && stackInSlot == player.getMainHandItem()) {
+                return;
             }
         }
         super.clicked(slotId, dragType, clickTypeIn, player);

--- a/src/main/java/com/direwolf20/laserio/common/containers/CardRedstoneContainer.java
+++ b/src/main/java/com/direwolf20/laserio/common/containers/CardRedstoneContainer.java
@@ -1,6 +1,7 @@
 package com.direwolf20.laserio.common.containers;
 
 import com.direwolf20.laserio.common.blockentities.LaserNodeBE;
+import com.direwolf20.laserio.common.items.cards.BaseCard;
 import com.direwolf20.laserio.setup.Registration;
 import net.minecraft.core.BlockPos;
 import net.minecraft.network.FriendlyByteBuf;
@@ -49,28 +50,18 @@ public class CardRedstoneContainer extends AbstractContainerMenu {
 
     @Override
     public void clicked(int slotId, int dragType, ClickType clickTypeIn, Player player) {
+        if (slotId >= 0) {
+            ItemStack stackInSlot = slots.get(slotId).getItem();
+            if (stackInSlot.getItem() instanceof BaseCard && stackInSlot == player.getMainHandItem()) {
+                return;
+            }
+        }
         super.clicked(slotId, dragType, clickTypeIn, player);
     }
 
     @Override
     public ItemStack quickMoveStack(Player playerIn, int index) {
-        ItemStack itemstack = ItemStack.EMPTY;
-        /*Slot slot = this.slots.get(index);
-        if (slot != null && slot.hasItem()) {
-            ItemStack currentStack = slot.getItem().copy();
-            currentStack.setCount(1);
-            //Only do this if we click from the players inventory
-            if (index >= SLOTS) {
-                for (int i = 0; i < SLOTS; i++) { //Loop through slots
-                    handler.setStackInSlot(i, ItemStack.EMPTY); //Clear the current slots
-                }
-                if (!this.moveItemStackTo(currentStack, 0, SLOTS, false)) {
-                    return ItemStack.EMPTY;
-                }
-            }
-        }*/
-        // No Op
-        return itemstack;
+        return ItemStack.EMPTY;
     }
 
     private int addSlotRange(IItemHandler handler, int index, int x, int y, int amount, int dx) {

--- a/src/main/java/com/direwolf20/laserio/common/containers/FilterBasicContainer.java
+++ b/src/main/java/com/direwolf20/laserio/common/containers/FilterBasicContainer.java
@@ -5,6 +5,7 @@ import com.direwolf20.laserio.common.containers.customhandler.CardItemHandler;
 import com.direwolf20.laserio.common.containers.customhandler.FilterBasicHandler;
 import com.direwolf20.laserio.common.containers.customslot.FilterBasicSlot;
 import com.direwolf20.laserio.common.items.cards.BaseCard;
+import com.direwolf20.laserio.common.items.filters.BaseFilter;
 import com.direwolf20.laserio.setup.Registration;
 import net.minecraft.core.BlockPos;
 import net.minecraft.network.FriendlyByteBuf;
@@ -61,9 +62,11 @@ public class FilterBasicContainer extends AbstractContainerMenu {
 
     @Override
     public void clicked(int slotId, int dragType, ClickType clickTypeIn, Player player) {
-        if (slotId >= 0 && slotId < SLOTS) {
-            //System.out.println("Skipping!");
-            return;
+        if (slotId >= 0) {
+            ItemStack stackInSlot = slots.get(slotId).getItem();
+            if (stackInSlot.getItem() instanceof BaseFilter && stackInSlot == player.getMainHandItem() || slotId < SLOTS) {
+                return;
+            }
         }
         super.clicked(slotId, dragType, clickTypeIn, player);
     }

--- a/src/main/java/com/direwolf20/laserio/common/containers/FilterCountContainer.java
+++ b/src/main/java/com/direwolf20/laserio/common/containers/FilterCountContainer.java
@@ -5,6 +5,7 @@ import com.direwolf20.laserio.common.containers.customhandler.CardItemHandler;
 import com.direwolf20.laserio.common.containers.customhandler.FilterCountHandler;
 import com.direwolf20.laserio.common.containers.customslot.FilterBasicSlot;
 import com.direwolf20.laserio.common.items.cards.BaseCard;
+import com.direwolf20.laserio.common.items.filters.BaseFilter;
 import com.direwolf20.laserio.common.items.filters.FilterCount;
 import com.direwolf20.laserio.setup.Registration;
 import net.minecraft.core.BlockPos;
@@ -56,9 +57,11 @@ public class FilterCountContainer extends AbstractContainerMenu {
 
     @Override
     public void clicked(int slotId, int dragType, ClickType clickTypeIn, Player player) {
-        if (slotId >= 0 && slotId < SLOTS) {
-            //System.out.println("Skipping!");
-            return;
+        if (slotId >= 0) {
+            ItemStack stackInSlot = slots.get(slotId).getItem();
+            if (stackInSlot.getItem() instanceof BaseFilter && stackInSlot == player.getMainHandItem() || slotId < SLOTS) {
+                return;
+            }
         }
         super.clicked(slotId, dragType, clickTypeIn, player);
     }

--- a/src/main/java/com/direwolf20/laserio/common/containers/FilterNBTContainer.java
+++ b/src/main/java/com/direwolf20/laserio/common/containers/FilterNBTContainer.java
@@ -5,6 +5,7 @@ import com.direwolf20.laserio.common.containers.customhandler.CardItemHandler;
 import com.direwolf20.laserio.common.containers.customhandler.FilterBasicHandler;
 import com.direwolf20.laserio.common.containers.customslot.FilterBasicSlot;
 import com.direwolf20.laserio.common.items.cards.BaseCard;
+import com.direwolf20.laserio.common.items.filters.BaseFilter;
 import com.direwolf20.laserio.setup.Registration;
 import net.minecraft.core.BlockPos;
 import net.minecraft.network.FriendlyByteBuf;
@@ -60,9 +61,11 @@ public class FilterNBTContainer extends AbstractContainerMenu {
 
     @Override
     public void clicked(int slotId, int dragType, ClickType clickTypeIn, Player player) {
-        if (slotId >= 0 && slotId < SLOTS) {
-            //System.out.println("Skipping!");
-            return;
+        if (slotId >= 0) {
+            ItemStack stackInSlot = slots.get(slotId).getItem();
+            if (stackInSlot.getItem() instanceof BaseFilter && stackInSlot == player.getMainHandItem() || slotId < SLOTS) {
+                return;
+            }
         }
         super.clicked(slotId, dragType, clickTypeIn, player);
     }

--- a/src/main/java/com/direwolf20/laserio/common/containers/FilterTagContainer.java
+++ b/src/main/java/com/direwolf20/laserio/common/containers/FilterTagContainer.java
@@ -5,6 +5,7 @@ import com.direwolf20.laserio.common.containers.customhandler.CardItemHandler;
 import com.direwolf20.laserio.common.containers.customhandler.FilterBasicHandler;
 import com.direwolf20.laserio.common.containers.customslot.FilterBasicSlot;
 import com.direwolf20.laserio.common.items.cards.BaseCard;
+import com.direwolf20.laserio.common.items.filters.BaseFilter;
 import com.direwolf20.laserio.setup.Registration;
 import net.minecraft.core.BlockPos;
 import net.minecraft.network.FriendlyByteBuf;
@@ -60,9 +61,11 @@ public class FilterTagContainer extends AbstractContainerMenu {
 
     @Override
     public void clicked(int slotId, int dragType, ClickType clickTypeIn, Player player) {
-        if (slotId >= 0 && slotId < SLOTS) {
-            //System.out.println("Skipping!");
-            return;
+        if (slotId >= 0) {
+            ItemStack stackInSlot = slots.get(slotId).getItem();
+            if (stackInSlot.getItem() instanceof BaseFilter && stackInSlot == player.getMainHandItem() || slotId < SLOTS) {
+                return;
+            }
         }
         super.clicked(slotId, dragType, clickTypeIn, player);
     }

--- a/src/main/java/com/direwolf20/laserio/common/containers/LaserNodeContainer.java
+++ b/src/main/java/com/direwolf20/laserio/common/containers/LaserNodeContainer.java
@@ -70,17 +70,17 @@ public class LaserNodeContainer extends AbstractContainerMenu {
     @Override
     public void clicked(int slotId, int dragType, ClickType clickTypeIn, Player player) {
         if (slotId >= 0) {
-            if (slotId < SLOTS && slots.get(slotId) instanceof CardHolderSlot) {
-                ItemStack carriedItem = getCarried();
-                ItemStack stackInSlot = slots.get(slotId).getItem();
+            Slot slot = slots.get(slotId);
+            ItemStack stackInSlot = slot.getItem();
+            if (slotId < SLOTS && slot instanceof CardHolderSlot) {
                 if (stackInSlot.getMaxStackSize() == 1 && stackInSlot.getCount() > 1) {
-                    if (!carriedItem.isEmpty() && !stackInSlot.isEmpty() && !ItemStack.isSameItemSameTags(carriedItem, stackInSlot))
+                    ItemStack carriedItem = getCarried();
+                    if (!carriedItem.isEmpty() && !stackInSlot.isEmpty() && !ItemStack.isSameItemSameTags(carriedItem, stackInSlot)) {
                         return;
+                    }
                 }
-            } else {
-                ItemStack slotItem = slots.get(slotId).getItem();
-                if (slotItem.getItem() instanceof CardHolder)
-                    return;
+            } else if (stackInSlot.getItem() instanceof CardHolder) {
+                return;
             }
         }
         super.clicked(slotId, dragType, clickTypeIn, player);


### PR DESCRIPTION
* Add the Card Holder's gui to Energy Cards' screen if Energy Overclockers are enabled and the player has a Card Holder in their inventory
* Add checks to prevent the Card Holder/Card/Filter from being dropped while the player is configuring it (this also prevents a duplication glitch)