### PR TITLE
Fixed crash caused by out of bound array access.

### DIFF
--- a/src/main/java/com/direwolf20/laserio/util/MiscTools.java
+++ b/src/main/java/com/direwolf20/laserio/util/MiscTools.java
@@ -20,7 +20,10 @@ public class MiscTools {
     }
 
     public static Vector3f findOffset(Direction direction, int slot, Vector3f[] offsets) {
-        Vector3f offsetVector = new Vector3f(offsets[slot]);
+        Vector3f offsetVector = new Vector3f();
+        if (slot < offsets.length) {
+            offsetVector = new Vector3f(offsets[slot]);
+        }
         switch (direction) {
             case UP -> {
                 Quaternionf quaternionf = Axis.XP.rotationDegrees(-270);


### PR DESCRIPTION
Fixed a crash in the rendering code cause by out of bounds array access by first doing bounds checks.

Resolves crash in issue #57. 