### PR TITLE
Fix Card Cloner pasting and code refactoring

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -88,13 +88,13 @@ minecraft {
 
             // Comma-separated list of namespaces to load gametests from. Empty = all namespaces.
             property 'forge.enabledGameTestNamespaces', mod_id
-    
+
             //Patchouli
             property 'mixin.env.remapRefMap', 'true'
             property 'mixin.env.refMapRemappingFile', "${projectDir}/build/createSrgToMcp/output.srg"
-         
-             arg "-mixin.config=${mod_id}.mixins.json"
-             
+
+            arg "-mixin.config=${mod_id}.mixins.json"
+
             mods {
                 "${mod_id}" {
                     source sourceSets.main

--- a/src/main/java/com/direwolf20/laserio/client/events/KeybindHandler.java
+++ b/src/main/java/com/direwolf20/laserio/client/events/KeybindHandler.java
@@ -26,7 +26,7 @@ public class KeybindHandler {
             InputConstants.Type.KEYSYM,
             GLFW.GLFW_KEY_O,
             LaserIO.MODNAME
-        );
+    );
     public static final KeyMapping TOGGLE_CARD_HOLDER_PULLING = new KeyMapping(
             "key.laserio.toggle_card_holder_pulling",
             KeyConflictContext.IN_GAME,
@@ -34,7 +34,7 @@ public class KeybindHandler {
             InputConstants.Type.KEYSYM,
             GLFW.GLFW_KEY_O,
             LaserIO.MODNAME
-        );
+    );
 
     @SubscribeEvent
     public void onKeyInput(InputEvent.Key event) {

--- a/src/main/java/com/direwolf20/laserio/client/screens/LaserNodeScreen.java
+++ b/src/main/java/com/direwolf20/laserio/client/screens/LaserNodeScreen.java
@@ -171,12 +171,11 @@ public class LaserNodeScreen extends AbstractContainerScreen<LaserNodeContainer>
     @Override
     public boolean mouseClicked(double x, double y, int btn) {
         if (hoveredSlot != null && container.getCarried().getItem() instanceof CardCloner) {
-            if (hoveredSlot instanceof LaserNodeSlot && !hoveredSlot.getItem().isEmpty())
-            if (btn == 0) { //Left click
-                PacketHandler.sendToServer(new PacketCopyPasteCard(hoveredSlot.getSlotIndex(), true));
-            }
-            if (btn == 1) { //Right click
-                PacketHandler.sendToServer(new PacketCopyPasteCard(hoveredSlot.getSlotIndex(), false));
+            if (hoveredSlot instanceof LaserNodeSlot && !hoveredSlot.getItem().isEmpty()) {
+                if (btn == 0) //Left click
+                    PacketHandler.sendToServer(new PacketCopyPasteCard(hoveredSlot.getSlotIndex(), true));
+                else if (btn == 1) //Right click
+                    PacketHandler.sendToServer(new PacketCopyPasteCard(hoveredSlot.getSlotIndex(), false));
             }
             return true;
         }
@@ -210,10 +209,9 @@ public class LaserNodeScreen extends AbstractContainerScreen<LaserNodeContainer>
             Minecraft.getInstance().getSoundManager().play(SimpleSoundInstance.forUI(SoundEvents.UI_BUTTON_CLICK, 1.0F));
             return true;
         }
-
-        if (hoveredSlot == null || hoveredSlot.getItem().isEmpty() || !(hoveredSlot.getItem().getItem() instanceof BaseCard))
+        if (hoveredSlot == null || hoveredSlot.getItem().isEmpty() || !(hoveredSlot.getItem().getItem() instanceof BaseCard)) {
             return super.mouseClicked(x, y, btn);
-
+        }
         if (btn == 1 && hoveredSlot instanceof LaserNodeSlot) { //Right click
             int slot = hoveredSlot.getSlotIndex();
             PacketHandler.sendToServer(new PacketOpenCard(slot, container.tile.getBlockPos(), hasShiftDown()));

--- a/src/main/java/com/direwolf20/laserio/common/blocks/LaserNode.java
+++ b/src/main/java/com/direwolf20/laserio/common/blocks/LaserNode.java
@@ -84,12 +84,12 @@ public class LaserNode extends BaseLaserBlock implements EntityBlock {
     @Override
     public InteractionResult use(BlockState state, Level level, BlockPos pos, Player player, InteractionHand hand, BlockHitResult result) {
         ItemStack heldItem = player.getMainHandItem();
-        if (heldItem.getItem() instanceof LaserWrench)
+        if (heldItem.getItem() instanceof LaserWrench) {
             return InteractionResult.PASS;
+        }
         if (!level.isClientSide) {
             BlockEntity be = level.getBlockEntity(pos);
             if (be instanceof LaserNodeBE) {
-
                 if (heldItem.getItem() instanceof BaseCard) {
                     LazyOptional<IItemHandler> itemHandler = be.getCapability(ForgeCapabilities.ITEM_HANDLER, result.getDirection());
                     itemHandler.ifPresent(h -> {
@@ -98,13 +98,16 @@ public class LaserNode extends BaseLaserBlock implements EntityBlock {
                     });
                 } else {
                     Direction direction;
-                    if (player.isShiftKeyDown())
+                    if (player.isShiftKeyDown()) {
                         direction = result.getDirection().getOpposite();
-                    else
+                    } else {
                         direction = result.getDirection();
+                    }
                     be.getCapability(ForgeCapabilities.ITEM_HANDLER, direction).ifPresent(h -> {
                         ItemStack cardHolder = findFirstCardHolder(player);
-                        if (!cardHolder.isEmpty()) CardHolder.getUUID(cardHolder);
+                        if (!cardHolder.isEmpty()) {
+                            CardHolder.getUUID(cardHolder);
+                        }
                         MenuProvider containerProvider = new MenuProvider() {
                             @Override
                             public Component getDisplayName() {
@@ -116,7 +119,6 @@ public class LaserNode extends BaseLaserBlock implements EntityBlock {
                                 return new LaserNodeContainer((LaserNodeBE) be, windowId, (byte) direction.ordinal(), playerInventory, playerEntity, (LaserNodeItemHandler) h, ContainerLevelAccess.create(be.getLevel(), be.getBlockPos()), cardHolder);
                             }
                         };
-
                         NetworkHooks.openScreen((ServerPlayer) player, containerProvider, (buf -> {
                             buf.writeBlockPos(pos);
                             buf.writeByte((byte) direction.ordinal());
@@ -127,23 +129,21 @@ public class LaserNode extends BaseLaserBlock implements EntityBlock {
             } else {
                 throw new IllegalStateException("Our named container provider is missing!");
             }
-
         }
         return InteractionResult.SUCCESS;
     }
 
     /** Custom Implementation of ItemHandlerHelper.insertItem for right clicking nodes with **/
     public static ItemStack insertItemToNode(IItemHandler dest, @Nonnull ItemStack stack, boolean simulate) {
-        if (dest == null || stack.isEmpty())
+        if (dest == null || stack.isEmpty()) {
             return stack;
-
+        }
         for (int i = 0; i < LaserNodeContainer.CARDSLOTS; i++) {
             stack = dest.insertItem(i, stack, simulate);
             if (stack.isEmpty()) {
                 return ItemStack.EMPTY;
             }
         }
-
         return stack;
     }
 
@@ -206,8 +206,9 @@ public class LaserNode extends BaseLaserBlock implements EntityBlock {
     public boolean canConnectRedstone(BlockState state, BlockGetter level, BlockPos pos, @Nullable Direction direction) {
         BlockEntity blockEntity = level.getBlockEntity(pos);
         if (blockEntity instanceof LaserNodeBE laserNodeBE) {
-            if ((direction == null) || !laserNodeBE.redstoneCardSides.containsKey((byte) direction.getOpposite().ordinal()))
+            if ((direction == null) || !laserNodeBE.redstoneCardSides.containsKey((byte) direction.getOpposite().ordinal())) {
                 return false;
+            }
             return laserNodeBE.redstoneCardSides.get((byte) direction.getOpposite().ordinal());
         }
         return false;
@@ -263,7 +264,6 @@ public class LaserNode extends BaseLaserBlock implements EntityBlock {
                     });
                 }
             }
-
         }
         super.onRemove(state, worldIn, pos, newState, isMoving);
     }

--- a/src/main/java/com/direwolf20/laserio/common/network/packets/PacketCopyPasteCard.java
+++ b/src/main/java/com/direwolf20/laserio/common/network/packets/PacketCopyPasteCard.java
@@ -13,7 +13,6 @@ import net.minecraft.core.Holder;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.network.FriendlyByteBuf;
 import net.minecraft.network.protocol.game.ClientboundSoundPacket;
-import net.minecraft.resources.ResourceLocation;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.sounds.SoundEvent;
 import net.minecraft.sounds.SoundEvents;
@@ -46,7 +45,7 @@ public class PacketCopyPasteCard {
         return new PacketCopyPasteCard(buffer.readInt(), buffer.readBoolean());
     }
 
-    public static void playSound(ServerPlayer player, Holder<SoundEvent> soundEventHolder) {
+    public static void playSound(ServerPlayer player, SoundEvent soundEvent) {
         // Get player's position
         double x = player.getX();
         double y = player.getY();
@@ -54,7 +53,7 @@ public class PacketCopyPasteCard {
 
         // Create the packet
         ClientboundSoundPacket packet = new ClientboundSoundPacket(
-                soundEventHolder, // The sound event
+                Holder.direct(soundEvent), // The sound event
                 SoundSource.PLAYERS, // The sound category
                 x, y, z, // The sound location
                 1, // The volume, 1 is normal, higher is louder
@@ -163,7 +162,7 @@ public class PacketCopyPasteCard {
                     CardCloner.setItemType(clonerStack, slotStack.getItem().toString());
                     CompoundTag compoundTag = slotStack.getTag() == null ? new CompoundTag() : slotStack.getTag();
                     CardCloner.saveSettings(clonerStack, compoundTag);
-                    playSound(player, Holder.direct(SoundEvent.createVariableRangeEvent(new ResourceLocation(SoundEvents.UI_CARTOGRAPHY_TABLE_TAKE_RESULT.getLocation().toString()))));
+                    playSound(player, SoundEvents.UI_CARTOGRAPHY_TABLE_TAKE_RESULT);
                 } else {
                     Item slotItem = slotStack.getItem();
                     if (slotItem.toString().equals(CardCloner.getItemType(clonerStack))) {
@@ -232,14 +231,13 @@ public class PacketCopyPasteCard {
                                 tempStack.setTag(compoundTag.copy());
                             }
                             container.getSlot(msg.slot).set(tempStack);
-                            playSound(player, Holder.direct(SoundEvent.createVariableRangeEvent(new ResourceLocation(SoundEvents.ENCHANTMENT_TABLE_USE.getLocation().toString()))));
+                            playSound(player, SoundEvents.ENCHANTMENT_TABLE_USE);
                             ((LaserNodeContainer)container).tile.updateThisNode();
                         } else {
-                            playSound(player, Holder.direct(SoundEvent.createVariableRangeEvent(new ResourceLocation(SoundEvents.WAXED_SIGN_INTERACT_FAIL.getLocation().toString()))));
+                            playSound(player, SoundEvents.WAXED_SIGN_INTERACT_FAIL);
                         }
-                    }
-                    else {
-                        playSound(player, Holder.direct(SoundEvent.createVariableRangeEvent(new ResourceLocation(SoundEvents.WAXED_SIGN_INTERACT_FAIL.getLocation().toString()))));
+                    } else {
+                        playSound(player, SoundEvents.WAXED_SIGN_INTERACT_FAIL);
                     }
                 }
             });

--- a/src/main/java/com/direwolf20/laserio/datagen/LaserIOLanguageProvider.java
+++ b/src/main/java/com/direwolf20/laserio/datagen/LaserIOLanguageProvider.java
@@ -13,6 +13,7 @@ public class LaserIOLanguageProvider extends LanguageProvider {
 
     @Override
     protected void addTranslations() {
+        //Items names
         add("itemGroup." + ModSetup.TAB_NAME, LaserIO.MODNAME);
         add(Registration.LaserConnector.get(), "Laser Connector");
         add(Registration.LaserConnectorAdv.get(), "Advanced Laser Connector");
@@ -35,6 +36,7 @@ public class LaserIOLanguageProvider extends LanguageProvider {
         add(Registration.Overclocker_Node.get(), "Node Overclocker");
         add(Registration.Logistic_Overclocker_Card.get(), "Logistic Overclocker");
 
+        //Screens informations
         add("screen.laserio.extractamt", "Transfer Amount");
         add("screen.laserio.tickSpeed", "Speed (Ticks)");
 
@@ -100,15 +102,7 @@ public class LaserIOLanguageProvider extends LanguageProvider {
         add("screen.laserio.nbttrue", "Match NBT");
         add("screen.laserio.nbtfalse", "Ignore NBT");
 
-        add("message.laserio.wrenchrange", "Connection exceeds maximum range of %d");
-        add("message.laserio.card_holder_pulling_enabled", "Card Holder pulling enabled");
-        add("message.laserio.card_holder_pulling_disabled", "Card Holder pulling disabled");
-
-        //Keybinds
-        add("key.laserio.open_card_holder", "Open Card Holder");
-        add("key.laserio.toggle_card_holder_pulling", "Toggle Card Holder Pulling");
-
-        //Card Tooltips
+        //Cards tooltips
         add("laserio.tooltip.item.show_settings", "Hold shift to show settings");
         add("laserio.tooltip.item.card.mode", "Mode: ");
         add("laserio.tooltip.item.card.channel", "Channel: ");
@@ -128,16 +122,25 @@ public class LaserIOLanguageProvider extends LanguageProvider {
         add("laserio.tooltip.item.card.Overclockers", "Overclockers: ");
         add("laserio.tooltip.item.card.None", "None");
 
-        //Energy Overclockers Tooltip
+        //Energy Overclockers tooltip
         add("laserio.tooltip.item.energy_overclocker.max_fe", "Max %d FE/operation");
 
-        //Filter Tooltips
+        //Filters tooltips
         add("laserio.tooltip.item.filter.type", "Type: ");
         add("laserio.tooltip.item.filter.type.allow", "Allow");
         add("laserio.tooltip.item.filter.type.deny", "Deny");
         add("laserio.tooltip.item.filter.nbt", "Match NBT: ");
         add("laserio.tooltip.item.filter.nbt.allow", "True");
         add("laserio.tooltip.item.filter.nbt.deny", "False");
+
+        //Client messages
+        add("message.laserio.wrenchrange", "Connection exceeds maximum range of %d");
+        add("message.laserio.card_holder_pulling_enabled", "Card Holder pulling enabled");
+        add("message.laserio.card_holder_pulling_disabled", "Card Holder pulling disabled");
+
+        //Keybinds
+        add("key.laserio.open_card_holder", "Open Card Holder");
+        add("key.laserio.toggle_card_holder_pulling", "Toggle Card Holder Pulling");
 
         //Curios Card Holder slot
         add("curios.identifier.card_holder", "Card Holder");


### PR DESCRIPTION
Prevent the Card Cloner from pasting configurations on non-LaserNode slots.
Improve the play sound method in the copy paste packet.
Remove some trailing spaces and add curly brackets.
Add some comments to the language provider class