### PR TITLE
Let energy pushing support handle multiple receive actions

### DIFF
--- a/src/main/java/com/direwolf20/laserio/util/ExtractorCardCache.java
+++ b/src/main/java/com/direwolf20/laserio/util/ExtractorCardCache.java
@@ -15,7 +15,7 @@ public class ExtractorCardCache extends BaseCardCache {
     public int remainingSleep;
     public boolean exact;
     public int roundRobin;
-    public boolean externallyManaged;
+    public int energyReceivedExternally;
 
     public ExtractorCardCache(Direction direction, ItemStack cardItem, int cardSlot, LaserNodeBE be) {
         super(direction, cardItem, cardSlot, be);
@@ -38,7 +38,7 @@ public class ExtractorCardCache extends BaseCardCache {
 
         this.exact = BaseCard.getExact(cardItem);
         this.roundRobin = BaseCard.getRoundRobin(cardItem);
-        this.externallyManaged = false;
+        this.energyReceivedExternally = 0;
     }
 
     public int decrementSleep() {


### PR DESCRIPTION
Fix energy pushing support by letting multiple receive actions happen within the same operation keeping track of the total amount of energy transferred