### PR TITLE
Fix NBT Filter adding empty tag to items with cold cache

### DIFF
--- a/src/main/java/com/direwolf20/laserio/util/BaseCardCache.java
+++ b/src/main/java/com/direwolf20/laserio/util/BaseCardCache.java
@@ -243,10 +243,12 @@ public class BaseCardCache {
                 }
             }
         } else if (filterCard.getItem() instanceof FilterNBT) {
-            for (String tag : testStack.getOrCreateTag().getAllKeys()) {
-                if (filterNBTs.contains(tag)) {
-                    filterCache.put(key, isAllowList);
-                    return isAllowList;
+            if (testStack.hasTag()) {
+                for (String tag : testStack.getOrCreateTag().getAllKeys()) {
+                    if (filterNBTs.contains(tag)) {
+                        filterCache.put(key, isAllowList);
+                        return isAllowList;
+                    }
                 }
             }
         } else {


### PR DESCRIPTION
NBT Filters used to add an empty tag to the transferred ItemStack if its cache was cold. 
This problem is now solved by checking if the ItemStack has tags before trying to work with them.

Fixes https://github.com/Direwolf20-MC/LaserIO/issues/334