### PR TITLE
Add shader effects workarounds in case Oculus is loaded

### DIFF
--- a/src/main/java/com/direwolf20/laserio/client/blockentityrenders/LaserNodeBERender.java
+++ b/src/main/java/com/direwolf20/laserio/client/blockentityrenders/LaserNodeBERender.java
@@ -11,7 +11,7 @@ import org.joml.Vector3f;
 import java.awt.Color;
 
 public class LaserNodeBERender extends BaseLaserBERender<LaserNodeBE> {
-    public static final Vector3f[] offsets = {
+    public static final Vector3f[] OFFSETS = {
             new Vector3f(0.65f, 0.65f, 0.5f),
             new Vector3f(0.5f, 0.65f, 0.5f),
             new Vector3f(0.35f, 0.65f, 0.5f),
@@ -22,7 +22,7 @@ public class LaserNodeBERender extends BaseLaserBERender<LaserNodeBE> {
             new Vector3f(0.5f, 0.35f, 0.5f),
             new Vector3f(0.35f, 0.35f, 0.5f)
     };
-    public static final Color colors[] = {
+    public static final Color[] COLORS = {
             new Color(255, 255, 255),
             new Color(249, 128, 29),
             new Color(198, 79, 189),
@@ -41,17 +41,16 @@ public class LaserNodeBERender extends BaseLaserBERender<LaserNodeBE> {
             new Color(29, 28, 33)
     };
 
-
     public LaserNodeBERender(BlockEntityRendererProvider.Context context) {
         super(context);
-
     }
 
     @Override
     public void render(LaserNodeBE blockentity, float partialTicks, PoseStack matrixStackIn, MultiBufferSource bufferIn, int combinedLightsIn, int combinedOverlayIn) {
         super.render(blockentity, partialTicks, matrixStackIn, bufferIn, combinedLightsIn, combinedOverlayIn);
-        if (!blockentity.rendersChecked)
+        if (!blockentity.rendersChecked) {
             blockentity.populateRenderList();
+        }
         DelayedRenderer.addConnecting(blockentity);
     }
 }

--- a/src/main/java/com/direwolf20/laserio/client/events/ClientEvents.java
+++ b/src/main/java/com/direwolf20/laserio/client/events/ClientEvents.java
@@ -21,12 +21,17 @@ import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.phys.BlockHitResult;
 import net.minecraftforge.client.event.CustomizeGuiOverlayEvent;
 import net.minecraftforge.client.event.RenderLevelStageEvent;
+import net.minecraftforge.client.event.RenderLevelStageEvent.Stage;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
+import net.minecraftforge.fml.ModList;
 
 public class ClientEvents {
+    public static final boolean IS_OCULUS_LOADED = ModList.get().isLoaded("oculus");
+    private static final Stage RENDERING_STAGE = IS_OCULUS_LOADED ? Stage.AFTER_TRANSLUCENT_BLOCKS : Stage.AFTER_CUTOUT_BLOCKS;
+
     @SubscribeEvent
     static void renderWorldLastEvent(RenderLevelStageEvent evt) {
-        if (evt.getStage() != RenderLevelStageEvent.Stage.AFTER_CUTOUT_BLOCKS) {
+        if (evt.getStage() != RENDERING_STAGE) {
             return;
         }
         Player player = Minecraft.getInstance().player;

--- a/src/main/java/com/direwolf20/laserio/client/renderer/BlockOverlayRender.java
+++ b/src/main/java/com/direwolf20/laserio/client/renderer/BlockOverlayRender.java
@@ -11,7 +11,6 @@ import net.minecraft.client.renderer.MultiBufferSource;
 import net.minecraft.core.BlockPos;
 import net.minecraft.world.phys.Vec3;
 import net.minecraftforge.client.event.RenderLevelStageEvent;
-
 import org.joml.Matrix4f;
 
 import java.awt.Color;
@@ -30,9 +29,7 @@ public class BlockOverlayRender {
         matrix.pushPose();
         matrix.translate(-view.x(), -view.y(), -view.z());
 
-        VertexConsumer builder;
-        //MyRenderType.updateRenders();
-        builder = buffer.getBuffer(MyRenderType.BlockOverlay);
+        VertexConsumer builder = buffer.getBuffer(MyRenderType.BLOCK_OVERLAY);
 
         matrix.pushPose();
         matrix.translate(pos.getX(), pos.getY(), pos.getZ());
@@ -45,7 +42,6 @@ public class BlockOverlayRender {
         matrix.popPose();
 
         matrix.popPose();
-        //RenderSystem.disableDepthTest();
-        buffer.endBatch(MyRenderType.BlockOverlay);
+        buffer.endBatch(MyRenderType.BLOCK_OVERLAY);
     }
 }

--- a/src/main/java/com/direwolf20/laserio/client/renderer/DelayedRenderer.java
+++ b/src/main/java/com/direwolf20/laserio/client/renderer/DelayedRenderer.java
@@ -15,13 +15,13 @@ public class DelayedRenderer {
 
     public static void render(PoseStack matrixStackIn) {
         if (beRenders.size() > 0) {
-            RenderUtils.drawLasersLast2(beRenders, matrixStackIn);
+            RenderUtils.drawLasers(beRenders, matrixStackIn);
         }
     }
 
     public static void renderConnections(PoseStack matrixStackIn) {
         if (beConnectingRenders.isEmpty()) return;
-        RenderUtils.drawConnectingLasersLast4(beConnectingRenders, matrixStackIn);
+        RenderUtils.drawConnectingLasers(beConnectingRenders, matrixStackIn);
         beConnectingRenders.clear();
     }
 

--- a/src/main/java/com/direwolf20/laserio/client/renderer/MyRenderType.java
+++ b/src/main/java/com/direwolf20/laserio/client/renderer/MyRenderType.java
@@ -1,74 +1,52 @@
 package com.direwolf20.laserio.client.renderer;
 
+import com.direwolf20.laserio.client.events.ClientEvents;
 import com.direwolf20.laserio.common.LaserIO;
 import com.mojang.blaze3d.vertex.DefaultVertexFormat;
 import com.mojang.blaze3d.vertex.VertexFormat;
+import net.minecraft.client.renderer.GameRenderer;
+import net.minecraft.client.renderer.RenderStateShard;
 import net.minecraft.client.renderer.RenderType;
 import net.minecraft.resources.ResourceLocation;
 
 public class MyRenderType extends RenderType {
-    private final static ResourceLocation laserBeam = new ResourceLocation(LaserIO.MODID + ":textures/misc/laser.png");
-    private final static ResourceLocation laserBeam2 = new ResourceLocation(LaserIO.MODID + ":textures/misc/laser2.png");
-    private final static ResourceLocation laserBeamGlow = new ResourceLocation(LaserIO.MODID + ":textures/misc/laser_glow.png");
+    private static final ResourceLocation SMALL_LASER_BEAM_TEXTURE = new ResourceLocation(LaserIO.MODID, "textures/misc/laser.png");
+    private static final ResourceLocation BIG_LASER_BEAM_TEXTURE = new ResourceLocation(LaserIO.MODID, "textures/misc/laser2.png");
+    private static final VertexFormat VERTEX_FORMAT = ClientEvents.IS_OCULUS_LOADED ? DefaultVertexFormat.POSITION_TEX_LIGHTMAP_COLOR : DefaultVertexFormat.POSITION_COLOR_TEX_LIGHTMAP;
+    private static final RenderStateShard.ShaderStateShard POSITION_TEX_LIGHTMAP_COLOR_SHADER = new RenderStateShard.ShaderStateShard(GameRenderer::getPositionTexLightmapColorShader);
+    private static final RenderStateShard.ShaderStateShard SHADER = ClientEvents.IS_OCULUS_LOADED ? POSITION_TEX_LIGHTMAP_COLOR_SHADER : POSITION_COLOR_TEX_LIGHTMAP_SHADER;
 
-    // Dummy
+    //Dummy
     public MyRenderType(String name, VertexFormat format, VertexFormat.Mode p_i225992_3_, int p_i225992_4_, boolean p_i225992_5_, boolean p_i225992_6_, Runnable runnablePre, Runnable runnablePost) {
         super(name, format, p_i225992_3_, p_i225992_4_, p_i225992_5_, p_i225992_6_, runnablePre, runnablePost);
     }
 
-    public static void updateRenders() {
-
+    private static RenderType createRenderType(String name, ResourceLocation texture, RenderStateShard.LayeringStateShard layering, RenderStateShard.WriteMaskStateShard writeMask) {
+        return create(
+                name,
+                VERTEX_FORMAT,
+                VertexFormat.Mode.QUADS,
+                256,
+                false,
+                false,
+                RenderType.CompositeState.builder()
+                        .setTextureState(new TextureStateShard(texture, false, false))
+                        .setShaderState(SHADER)
+                        .setLayeringState(layering)
+                        .setTransparencyState(TRANSLUCENT_TRANSPARENCY)
+                        .setDepthTestState(LEQUAL_DEPTH_TEST)
+                        .setCullState(CULL)
+                        .setLightmapState(NO_LIGHTMAP)
+                        .setWriteMaskState(writeMask)
+                        .createCompositeState(false)
+        );
     }
 
-    public static final RenderType LASER_MAIN_BEAM = create("MiningLaserMainBeam",
-            DefaultVertexFormat.POSITION_COLOR_TEX_LIGHTMAP, VertexFormat.Mode.QUADS, 256, false, false,
-            RenderType.CompositeState.builder().setTextureState(new TextureStateShard(laserBeam2, false, false))
-                    .setShaderState(ShaderStateShard.POSITION_COLOR_TEX_LIGHTMAP_SHADER)
-                    .setLayeringState(NO_LAYERING)
-                    .setTransparencyState(TRANSLUCENT_TRANSPARENCY)
-                    .setDepthTestState(LEQUAL_DEPTH_TEST)
-                    .setCullState(CULL)
-                    .setLightmapState(NO_LIGHTMAP)
-                    .setWriteMaskState(COLOR_DEPTH_WRITE)
-                    .createCompositeState(false));
+    public static final RenderType LASER_MAIN_BEAM = createRenderType("MiningLaserMainBeam", BIG_LASER_BEAM_TEXTURE, NO_LAYERING, COLOR_DEPTH_WRITE);
+    public static final RenderType LASER_MAIN_CORE = createRenderType("MiningLaserCoreBeam", SMALL_LASER_BEAM_TEXTURE, VIEW_OFFSET_Z_LAYERING, COLOR_WRITE);
+    public static final RenderType CONNECTING_LASER = createRenderType("ConnectingLaser", SMALL_LASER_BEAM_TEXTURE, VIEW_OFFSET_Z_LAYERING, COLOR_WRITE);
 
-    public static final RenderType LASER_MAIN_ADDITIVE = create("MiningLaserAdditiveBeam",
-            DefaultVertexFormat.POSITION_COLOR_TEX_LIGHTMAP, VertexFormat.Mode.QUADS, 256, false, false,
-            RenderType.CompositeState.builder().setTextureState(new TextureStateShard(laserBeamGlow, false, false))
-                    .setShaderState(ShaderStateShard.POSITION_COLOR_TEX_LIGHTMAP_SHADER)
-                    .setLayeringState(VIEW_OFFSET_Z_LAYERING)
-                    .setTransparencyState(TRANSLUCENT_TRANSPARENCY)
-                    .setDepthTestState(LEQUAL_DEPTH_TEST)
-                    .setCullState(NO_CULL)
-                    .setLightmapState(NO_LIGHTMAP)
-                    .setWriteMaskState(COLOR_WRITE)
-                    .createCompositeState(false));
-
-    public static final RenderType LASER_MAIN_CORE = create("MiningLaserCoreBeam",
-            DefaultVertexFormat.POSITION_COLOR_TEX_LIGHTMAP, VertexFormat.Mode.QUADS, 256, false, false,
-            RenderType.CompositeState.builder().setTextureState(new TextureStateShard(laserBeam, false, false))
-                    .setShaderState(ShaderStateShard.POSITION_COLOR_TEX_LIGHTMAP_SHADER)
-                    .setLayeringState(VIEW_OFFSET_Z_LAYERING)
-                    .setTransparencyState(TRANSLUCENT_TRANSPARENCY)
-                    .setDepthTestState(LEQUAL_DEPTH_TEST)
-                    .setCullState(CULL)
-                    .setLightmapState(NO_LIGHTMAP)
-                    .setWriteMaskState(COLOR_WRITE)
-                    .createCompositeState(false));
-
-    public static final RenderType CONNECTING_LASER = create("ConnectingLaser",
-            DefaultVertexFormat.POSITION_COLOR_TEX_LIGHTMAP, VertexFormat.Mode.QUADS, 256, false, false,
-            RenderType.CompositeState.builder().setTextureState(new TextureStateShard(laserBeam, false, false))
-                    .setShaderState(ShaderStateShard.POSITION_COLOR_TEX_LIGHTMAP_SHADER)
-                    .setLayeringState(VIEW_OFFSET_Z_LAYERING)
-                    .setTransparencyState(TRANSLUCENT_TRANSPARENCY)
-                    .setDepthTestState(LEQUAL_DEPTH_TEST)
-                    .setCullState(CULL)
-                    .setLightmapState(NO_LIGHTMAP)
-                    .setWriteMaskState(COLOR_WRITE)
-                    .createCompositeState(false));
-
-    public static final RenderType BlockOverlay = create("MiningLaserBlockOverlay",
+    public static final RenderType BLOCK_OVERLAY = create("MiningLaserBlockOverlay",
             DefaultVertexFormat.POSITION_COLOR, VertexFormat.Mode.QUADS, 256, false, false,
             RenderType.CompositeState.builder()
                     .setShaderState(ShaderStateShard.POSITION_COLOR_SHADER)

--- a/src/main/java/com/direwolf20/laserio/client/renderer/MyRenderType.java
+++ b/src/main/java/com/direwolf20/laserio/client/renderer/MyRenderType.java
@@ -49,13 +49,14 @@ public class MyRenderType extends RenderType {
     public static final RenderType BLOCK_OVERLAY = create("MiningLaserBlockOverlay",
             DefaultVertexFormat.POSITION_COLOR, VertexFormat.Mode.QUADS, 256, false, false,
             RenderType.CompositeState.builder()
-                    .setShaderState(ShaderStateShard.POSITION_COLOR_SHADER)
+                    .setTextureState(NO_TEXTURE)
+                    .setShaderState(POSITION_COLOR_SHADER)
                     .setLayeringState(VIEW_OFFSET_Z_LAYERING)
                     .setTransparencyState(TRANSLUCENT_TRANSPARENCY)
-                    .setTextureState(NO_TEXTURE)
                     .setDepthTestState(NO_DEPTH_TEST)
                     .setCullState(NO_CULL)
                     .setLightmapState(NO_LIGHTMAP)
                     .setWriteMaskState(COLOR_WRITE)
-                    .createCompositeState(false));
+                    .createCompositeState(false)
+    );
 }

--- a/src/main/java/com/direwolf20/laserio/common/items/CardCloner.java
+++ b/src/main/java/com/direwolf20/laserio/common/items/CardCloner.java
@@ -4,7 +4,6 @@ import com.direwolf20.laserio.client.blockentityrenders.LaserNodeBERender;
 import com.direwolf20.laserio.common.containers.CardEnergyContainer;
 import com.direwolf20.laserio.common.containers.CardItemContainer;
 import com.direwolf20.laserio.common.items.cards.BaseCard;
-
 import net.minecraft.ChatFormatting;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.screens.Screen;
@@ -88,7 +87,7 @@ public class CardCloner extends Item {
 
             toWrite = tooltipMaker("laserio.tooltip.item.card.channel", ChatFormatting.GRAY);
             int channel = !compoundTag.contains("channel") ? 0 : compoundTag.getByte("channel");;
-            toWrite.append(tooltipMaker(String.valueOf(channel), LaserNodeBERender.colors[channel].getRGB()));
+            toWrite.append(tooltipMaker(String.valueOf(channel), LaserNodeBERender.COLORS[channel].getRGB()));
             tooltip.add(toWrite);
             if (isRedstoneCard) {
                 return;

--- a/src/main/java/com/direwolf20/laserio/common/items/cards/BaseCard.java
+++ b/src/main/java/com/direwolf20/laserio/common/items/cards/BaseCard.java
@@ -85,7 +85,7 @@ public class BaseCard extends Item {
 
             toWrite = tooltipMaker("laserio.tooltip.item.card.channel", ChatFormatting.GRAY);
             int channel = getChannel(stack);
-            toWrite.append(tooltipMaker(String.valueOf(channel), LaserNodeBERender.colors[channel].getRGB()));
+            toWrite.append(tooltipMaker(String.valueOf(channel), LaserNodeBERender.COLORS[channel].getRGB()));
             tooltip.add(toWrite);
 
             int sneakyMode = getSneaky(stack);

--- a/src/main/java/com/direwolf20/laserio/integration/mekanism/MekanismCache.java
+++ b/src/main/java/com/direwolf20/laserio/integration/mekanism/MekanismCache.java
@@ -1,5 +1,6 @@
 package com.direwolf20.laserio.integration.mekanism;
 
+import com.direwolf20.laserio.client.blockentityrenders.LaserNodeBERender;
 import com.direwolf20.laserio.common.blockentities.LaserNodeBE;
 import com.direwolf20.laserio.common.blockentities.LaserNodeBE.SideConnection;
 import com.direwolf20.laserio.common.blocks.LaserNode;
@@ -15,6 +16,7 @@ import com.direwolf20.laserio.util.CardRender;
 import com.direwolf20.laserio.util.DimBlockPos;
 import com.direwolf20.laserio.util.ExtractorCardCache;
 import com.direwolf20.laserio.util.InserterCardCache;
+import com.direwolf20.laserio.util.MiscTools;
 import com.direwolf20.laserio.util.NodeSideCache;
 import com.direwolf20.laserio.util.SensorCardCache;
 import com.direwolf20.laserio.util.StockerCardCache;
@@ -44,10 +46,6 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Random;
 import java.util.concurrent.CopyOnWriteArrayList;
-
-import static com.direwolf20.laserio.client.blockentityrenders.LaserNodeBERender.offsets;
-import static com.direwolf20.laserio.integration.mekanism.MekanismStatics.isValidChemicalForHandler;
-import static com.direwolf20.laserio.util.MiscTools.findOffset;
 
 public class MekanismCache {
     private record LaserNodeChemicalHandler(LaserNodeBE be, IChemicalHandler<?, ?> handler) {
@@ -223,7 +221,6 @@ public class MekanismCache {
                 boolean foundItems = findChemicalStackForStocker(stockerCardCache, chemicalHandler, entry.getKey()); //Start looking for this item
                 if (foundItems)
                     return true;
-
             } else if (filter.getItem() instanceof FilterTag) {
                 //No-Op
             }
@@ -252,7 +249,7 @@ public class MekanismCache {
 
     public boolean canAnyChemicalFiltersFit(IChemicalHandler chemicalHandler, StockerCardCache stockerCardCache) {
         for (ChemicalStack<?> chemicalStack : stockerCardCache.mekanismCardCache.getFilteredChemicals()) {
-            if (!isValidChemicalForHandler(chemicalHandler, chemicalStack)) //Don't Check disparate types
+            if (!MekanismStatics.isValidChemicalForHandler(chemicalHandler, chemicalStack)) //Don't Check disparate types
                 continue;
             long amtReturned = chemicalHandler.insertChemical(chemicalStack, Action.SIMULATE).getAmount();
             if (amtReturned < chemicalStack.getAmount()) //If any fit
@@ -290,7 +287,6 @@ public class MekanismCache {
 
         if (filteredChemicalsList.isEmpty()) //If we have nothing left to look for! Probably only happens when its a count card.
             return false;
-
 
         //At this point we should have a list of fluids that we need to satisfy the stock request
         for (ChemicalStack<?> chemicalStack : filteredChemicalsList) {
@@ -333,7 +329,7 @@ public class MekanismCache {
     }
 
     public boolean canChemicalFitInTank(IChemicalHandler stockerTank, ChemicalStack<?> chemicalStack) {
-        if (!isValidChemicalForHandler(stockerTank, chemicalStack)) //Don't Check disparate types
+        if (!MekanismStatics.isValidChemicalForHandler(stockerTank, chemicalStack)) //Don't Check disparate types
             return false;
         return (stockerTank.insertChemical(chemicalStack, Action.SIMULATE).getAmount() < chemicalStack.getAmount());
     }
@@ -380,7 +376,6 @@ public class MekanismCache {
         }
         return false;
     }
-
 
     public boolean extractChemicalStack(ExtractorCardCache extractorCardCache, IChemicalHandler fromInventory, ChemicalStack<?> extractStack, ChemicalType chemicalType) {
         long totalAmtNeeded = extractStack.getAmount();
@@ -672,7 +667,7 @@ public class MekanismCache {
         if (targetState.getBlock() instanceof LaserNode) {
             targetState = level.getBlockState(fromPos);
             VoxelShape voxelShape = targetState.getShape(level, fromPos);
-            Vector3f extractOffset = findOffset(direction, partData.position, offsets);
+            Vector3f extractOffset = MiscTools.findOffset(direction, partData.position, LaserNodeBERender.OFFSETS);
             Vector3f insertOffset = CardRender.shapeOffset(extractOffset, voxelShape, fromPos, toPos, direction, level, targetState);
             ChemicalFlowParticleData data = new ChemicalFlowParticleData(chemicalStack, toPos.getX() + extractOffset.x(), toPos.getY() + extractOffset.y(), toPos.getZ() + extractOffset.z(), 10, chemicalStack.getType().toString());
             for (int i = 0; i < count; ++i) {
@@ -684,7 +679,7 @@ public class MekanismCache {
             }
         } else {
             VoxelShape voxelShape = targetState.getShape(level, toPos);
-            Vector3f extractOffset = findOffset(direction, partData.position, offsets);
+            Vector3f extractOffset = MiscTools.findOffset(direction, partData.position, LaserNodeBERender.OFFSETS);
             Vector3f insertOffset = CardRender.shapeOffset(extractOffset, voxelShape, fromPos, toPos, direction, level, targetState);
             ChemicalFlowParticleData data = new ChemicalFlowParticleData(chemicalStack, fromPos.getX() + insertOffset.x(), fromPos.getY() + insertOffset.y(), fromPos.getZ() + insertOffset.z(), 10, chemicalStack.getType().toString());
             for (int i = 0; i < count; ++i) {

--- a/src/main/java/com/direwolf20/laserio/integration/mekanism/MekanismStatics.java
+++ b/src/main/java/com/direwolf20/laserio/integration/mekanism/MekanismStatics.java
@@ -100,21 +100,24 @@ public class MekanismStatics {
     }
 
     public static boolean isValidChemicalForHandler(IChemicalHandler<?, ?> handler, ChemicalStack<?> chemicalStack) {
-        // Check if the handler is a gas handler
+        //Check if the handler is a gas handler
         if (handler instanceof IGasHandler) {
-            // Ensure the chemical stack is also a gas stack
+            //Ensure the chemical stack is also a gas stack
             return chemicalStack instanceof GasStack;
         }
+        //Check if the handler is a slurry handler
         if (handler instanceof ISlurryHandler) {
-            // Ensure the chemical stack is also a gas stack
+            //Ensure the chemical stack is also a slurry stack
             return chemicalStack instanceof SlurryStack;
         }
+        //Check if the handler is a pigment handler
         if (handler instanceof IPigmentHandler) {
-            // Ensure the chemical stack is also a gas stack
+            //Ensure the chemical stack is also a pigment stack
             return chemicalStack instanceof PigmentStack;
         }
+        //Check if the handler is an infusion handler
         if (handler instanceof IInfusionHandler) {
-            // Ensure the chemical stack is also a gas stack
+            //Ensure the chemical stack is also an infusion stack
             return chemicalStack instanceof InfusionStack;
         }
 

--- a/src/main/java/com/direwolf20/laserio/setup/ClientSetup.java
+++ b/src/main/java/com/direwolf20/laserio/setup/ClientSetup.java
@@ -132,10 +132,10 @@ public class ClientSetup {
         colors.register((stack, index) -> {
             if (index == 2) {
                 if (BaseCard.getTransferMode(stack) == (byte) 3) {
-                    Color color = LaserNodeBERender.colors[BaseCard.getRedstoneChannel(stack)];
+                    Color color = LaserNodeBERender.COLORS[BaseCard.getRedstoneChannel(stack)];
                     return color.getRGB();
                 } else {
-                    Color color = LaserNodeBERender.colors[BaseCard.getChannel(stack)];
+                    Color color = LaserNodeBERender.COLORS[BaseCard.getChannel(stack)];
                     return color.getRGB();
                 }
             }
@@ -144,10 +144,10 @@ public class ClientSetup {
         colors.register((stack, index) -> {
             if (index == 2) {
                 if (BaseCard.getTransferMode(stack) == (byte) 3) {
-                    Color color = LaserNodeBERender.colors[BaseCard.getRedstoneChannel(stack)];
+                    Color color = LaserNodeBERender.COLORS[BaseCard.getRedstoneChannel(stack)];
                     return color.getRGB();
                 } else {
-                    Color color = LaserNodeBERender.colors[BaseCard.getChannel(stack)];
+                    Color color = LaserNodeBERender.COLORS[BaseCard.getChannel(stack)];
                     return color.getRGB();
                 }
             }
@@ -157,10 +157,10 @@ public class ClientSetup {
             colors.register((stack, index) -> {
                 if (index == 2) {
                     if (BaseCard.getTransferMode(stack) == (byte) 3) {
-                        Color color = LaserNodeBERender.colors[BaseCard.getRedstoneChannel(stack)];
+                        Color color = LaserNodeBERender.COLORS[BaseCard.getRedstoneChannel(stack)];
                         return color.getRGB();
                     } else {
-                        Color color = LaserNodeBERender.colors[BaseCard.getChannel(stack)];
+                        Color color = LaserNodeBERender.COLORS[BaseCard.getChannel(stack)];
                         return color.getRGB();
                     }
                 }
@@ -170,10 +170,10 @@ public class ClientSetup {
         colors.register((stack, index) -> {
             if (index == 2) {
                 if (BaseCard.getTransferMode(stack) == (byte) 3) {
-                    Color color = LaserNodeBERender.colors[BaseCard.getRedstoneChannel(stack)];
+                    Color color = LaserNodeBERender.COLORS[BaseCard.getRedstoneChannel(stack)];
                     return color.getRGB();
                 } else {
-                    Color color = LaserNodeBERender.colors[BaseCard.getChannel(stack)];
+                    Color color = LaserNodeBERender.COLORS[BaseCard.getChannel(stack)];
                     return color.getRGB();
                 }
             }
@@ -181,7 +181,7 @@ public class ClientSetup {
         }, Registration.Card_Energy.get());
         colors.register((stack, index) -> {
             if (index == 2) {
-                Color color = LaserNodeBERender.colors[CardRedstone.getRedstoneChannel(stack)];
+                Color color = LaserNodeBERender.COLORS[CardRedstone.getRedstoneChannel(stack)];
                 return color.getRGB();
             }
             return 0xFFFFFFFF;

--- a/src/main/java/com/direwolf20/laserio/util/CardRender.java
+++ b/src/main/java/com/direwolf20/laserio/util/CardRender.java
@@ -11,8 +11,6 @@ import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.phys.shapes.VoxelShape;
 import org.joml.Vector3f;
 
-import static com.direwolf20.laserio.util.MiscTools.findOffset;
-
 public class CardRender {
     public Direction direction;
     public int cardSlot;
@@ -35,40 +33,51 @@ public class CardRender {
         endBlock = startBlock.relative(direction);
         BlockState targetState = level.getBlockState(endBlock);
         VoxelShape voxelShape = targetState.getShape(level, endBlock);
-        //System.out.println(voxelShape + ":" + voxelShape.getFaceShape(direction.getOpposite()));
-        if (((BaseCard) card.getItem()).getCardType() == BaseCard.CardType.ITEM) {
-            r = 0f;
-            g = 1f;
-            b = 0f;
-        } else if (((BaseCard) card.getItem()).getCardType() == BaseCard.CardType.FLUID) {
-            r = 0f;
-            g = 0f;
-            b = 1f;
-        } else if (((BaseCard) card.getItem()).getCardType() == BaseCard.CardType.ENERGY) {
-            r = 1f;
-            g = 1f;
-            b = 0f;
-        } else if (((BaseCard) card.getItem()).getCardType() == BaseCard.CardType.REDSTONE) {
-            r = 1f;
-            g = 0f;
-            b = 0f;
-        } else if (((BaseCard) card.getItem()).getCardType() == BaseCard.CardType.CHEMICAL) {
-            r = 1f;
-            g = 0f;
-            b = 1f;
+        BaseCard cardItem = (BaseCard) card.getItem();
+        switch (cardItem.getCardType()) {
+            case ITEM -> {
+                r = 0f;
+                g = 1f;
+                b = 0f;
+            }
+            case FLUID -> {
+                r = 0f;
+                g = 0f;
+                b = 1f;
+            }
+            case ENERGY -> {
+                r = 1f;
+                g = 1f;
+                b = 0f;
+            }
+            case REDSTONE -> {
+                r = 1f;
+                g = 0f;
+                b = 0f;
+            }
+            case CHEMICAL -> {
+                r = 1f;
+                g = 0f;
+                b = 1f;
+            }
+            default -> {
+                r = 0f;
+                g = 0f;
+                b = 0f;
+            }
         }
         if (!enabled) {
             r /= 4f;
             g /= 4f;
             b /= 4f;
         }
-        Vector3f offset = findOffset(direction, cardSlot, LaserNodeBERender.offsets);
+        Vector3f offset = MiscTools.findOffset(direction, cardSlot, LaserNodeBERender.offsets);
         Vector3f shapeOffset = shapeOffset(offset, voxelShape, startBlock, endBlock, direction, level, targetState);
         diffX = shapeOffset.x();
         diffY = shapeOffset.y();
         diffZ = shapeOffset.z();
         boolean reverse = !direction.equals(Direction.DOWN);
-        if (card.getItem() instanceof CardRedstone) {
+        if (cardItem instanceof CardRedstone) {
             if (BaseCard.getNamedTransferMode(card) != BaseCard.TransferMode.INSERT) {
                 reverse = !reverse;
             }
@@ -77,7 +86,7 @@ public class CardRender {
                 reverse = !reverse;
             }
         }
-        if (card.getItem() instanceof CardRedstone || BaseCard.getNamedTransferMode(card) == BaseCard.TransferMode.SENSOR) {
+        if (cardItem instanceof CardRedstone || BaseCard.getNamedTransferMode(card) == BaseCard.TransferMode.SENSOR) {
             floatColors = LaserNodeBERender.colors[BaseCard.getRedstoneChannel(card)].getColorComponents(new float[3]);
         } else {
             floatColors = LaserNodeBERender.colors[BaseCard.getChannel(card)].getColorComponents(new float[3]);
@@ -102,42 +111,42 @@ public class CardRender {
             diffZ = (float) (((voxelShape.bounds().maxZ - voxelShape.bounds().minZ) * diffZ) + voxelShape.bounds().minZ);
             if (direction.equals(Direction.WEST)) {
                 if (targetState.getOffset(level, endBlock).x != 0) {
-                    diffX = -1 - (float) (targetState.getOffset(level, endBlock).x + (float) 1 / 16 - ((voxelShape.bounds().maxX - voxelShape.bounds().minX)));
+                    diffX = -1 - (float) (targetState.getOffset(level, endBlock).x + (float) 1 / 16 - (voxelShape.bounds().maxX - voxelShape.bounds().minX));
                 } else {
                     diffX = -1 + (float) voxelShape.bounds().maxX;
                 }
                 offset.x = (offset.x() - 0.1875f);
             } else if (direction.equals(Direction.EAST)) {
                 if (targetState.getOffset(level, endBlock).x != 0) {
-                    diffX = 1 + (float) (targetState.getOffset(level, endBlock).x - (float) 1 / 16 + ((voxelShape.bounds().maxX - voxelShape.bounds().minX)));
+                    diffX = 1 + (float) (targetState.getOffset(level, endBlock).x - (float) 1 / 16 + (voxelShape.bounds().maxX - voxelShape.bounds().minX));
                 } else {
                     diffX = 1 + (float) voxelShape.bounds().minX;
                 }
                 offset.x = (offset.x() + 0.1875f);
             } else if (direction.equals(Direction.SOUTH)) {
                 if (targetState.getOffset(level, endBlock).z != 0) {
-                    diffZ = 1 + (float) (targetState.getOffset(level, endBlock).z - (float) 1 / 16 + ((voxelShape.bounds().maxZ - voxelShape.bounds().minZ)));
+                    diffZ = 1 + (float) (targetState.getOffset(level, endBlock).z - (float) 1 / 16 + (voxelShape.bounds().maxZ - voxelShape.bounds().minZ));
                 } else {
                     diffZ = 1 + (float) voxelShape.bounds().minZ;
                 }
                 offset.z = (offset.z() + 0.1875f);
             } else if (direction.equals(Direction.NORTH)) {
                 if (targetState.getOffset(level, endBlock).z != 0) {
-                    diffZ = (float) (targetState.getOffset(level, endBlock).z + (float) 1 / 16 - ((voxelShape.bounds().maxZ - voxelShape.bounds().minZ)));
+                    diffZ = (float) (targetState.getOffset(level, endBlock).z + (float) 1 / 16 - (voxelShape.bounds().maxZ - voxelShape.bounds().minZ));
                 } else {
                     diffZ = -1 + (float) voxelShape.bounds().maxZ;
                 }
                 offset.z = (offset.z() - 0.1875f);
             } else if (direction.equals(Direction.UP)) {
                 if (targetState.getOffset(level, endBlock).y != 0) {
-                    diffY = 1 + (float) (targetState.getOffset(level, endBlock).y - (float) 1 / 16 + ((voxelShape.bounds().maxY - voxelShape.bounds().minY)));
+                    diffY = 1 + (float) (targetState.getOffset(level, endBlock).y - (float) 1 / 16 + (voxelShape.bounds().maxY - voxelShape.bounds().minY));
                 } else {
                     diffY = 1 + (float) voxelShape.bounds().minY;
                 }
                 offset.y = (offset.y() + 0.1875f);
             } else if (direction.equals(Direction.DOWN)) {
                 if (targetState.getOffset(level, endBlock).y != 0) {
-                    diffY = (float) (targetState.getOffset(level, endBlock).y + (float) 1 / 16 - ((voxelShape.bounds().maxY - voxelShape.bounds().minY)));
+                    diffY = (float) (targetState.getOffset(level, endBlock).y + (float) 1 / 16 - (voxelShape.bounds().maxY - voxelShape.bounds().minY));
                 } else {
                     diffY = -1 + (float) voxelShape.bounds().maxY;
                 }

--- a/src/main/java/com/direwolf20/laserio/util/CardRender.java
+++ b/src/main/java/com/direwolf20/laserio/util/CardRender.java
@@ -71,7 +71,7 @@ public class CardRender {
             g /= 4f;
             b /= 4f;
         }
-        Vector3f offset = MiscTools.findOffset(direction, cardSlot, LaserNodeBERender.offsets);
+        Vector3f offset = MiscTools.findOffset(direction, cardSlot, LaserNodeBERender.OFFSETS);
         Vector3f shapeOffset = shapeOffset(offset, voxelShape, startBlock, endBlock, direction, level, targetState);
         diffX = shapeOffset.x();
         diffY = shapeOffset.y();
@@ -87,9 +87,9 @@ public class CardRender {
             }
         }
         if (cardItem instanceof CardRedstone || BaseCard.getNamedTransferMode(card) == BaseCard.TransferMode.SENSOR) {
-            floatColors = LaserNodeBERender.colors[BaseCard.getRedstoneChannel(card)].getColorComponents(new float[3]);
+            floatColors = LaserNodeBERender.COLORS[BaseCard.getRedstoneChannel(card)].getColorComponents(new float[3]);
         } else {
-            floatColors = LaserNodeBERender.colors[BaseCard.getChannel(card)].getColorComponents(new float[3]);
+            floatColors = LaserNodeBERender.COLORS[BaseCard.getChannel(card)].getColorComponents(new float[3]);
         }
         if (reverse) {
             endLaser = new Vector3f(offset.x(), offset.y(), offset.z());

--- a/src/main/java/com/direwolf20/laserio/util/MiscTools.java
+++ b/src/main/java/com/direwolf20/laserio/util/MiscTools.java
@@ -1,7 +1,6 @@
 package com.direwolf20.laserio.util;
 
 import com.mojang.math.Axis;
-
 import net.minecraft.ChatFormatting;
 import net.minecraft.core.Direction;
 import net.minecraft.nbt.CompoundTag;

--- a/src/main/java/com/direwolf20/laserio/util/MiscTools.java
+++ b/src/main/java/com/direwolf20/laserio/util/MiscTools.java
@@ -26,33 +26,27 @@ public class MiscTools {
             case UP -> {
                 Quaternionf quaternionf = Axis.XP.rotationDegrees(-270);
                 offsetVector = quaternionf.transform(offsetVector);
-                //offsetVector.transform(Vector3f.XP.rotationDegrees(-270));
                 offsetVector.add(0, 1, 0);
             }
             case DOWN -> {
                 Quaternionf quaternionf = Axis.XP.rotationDegrees(-90);
                 offsetVector = quaternionf.transform(offsetVector);
-                //offsetVector.transform(Vector3f.XP.rotationDegrees(-90));
                 offsetVector.add(0, 0, 1);
-                //reverse = false;
             }
-            //case NORTH -> offsetVector;
+            case NORTH -> {}
             case EAST -> {
                 Quaternionf quaternionf = Axis.YP.rotationDegrees(-90);
                 offsetVector = quaternionf.transform(offsetVector);
-                //offsetVector.transform(Vector3f.YP.rotationDegrees(-90));
                 offsetVector.add(1, 0, 0);
             }
             case SOUTH -> {
                 Quaternionf quaternionf = Axis.YP.rotationDegrees(-180);
                 offsetVector = quaternionf.transform(offsetVector);
-                //offsetVector.transform(Vector3f.YP.rotationDegrees(-180));
                 offsetVector.add(1, 0, 1);
             }
             case WEST -> {
                 Quaternionf quaternionf = Axis.YP.rotationDegrees(-270);
                 offsetVector = quaternionf.transform(offsetVector);
-                //offsetVector.transform(Vector3f.YP.rotationDegrees(-270));
                 offsetVector.add(0, 0, 1);
             }
         }


### PR DESCRIPTION
Improves #70 introducing some workarounds in case Oculus is loaded.
Fixes #61 almost completely (while a player holds the Laser Wrench and they selected a Node, the green overlay is rendered even through blocks)