### PR TITLE
Prevent item swapping using hotkeys in screens

### DIFF
--- a/src/main/java/com/direwolf20/laserio/client/screens/CardEnergyScreen.java
+++ b/src/main/java/com/direwolf20/laserio/client/screens/CardEnergyScreen.java
@@ -161,8 +161,9 @@ public class CardEnergyScreen extends AbstractContainerScreen<CardEnergyContaine
         for (int i = CardEnergyContainer.SLOTS; i < (CardEnergyContainer.SLOTS + CardHolderContainer.SLOTS); i++) {
             if (i >= container.slots.size()) continue;
             Slot slot = container.getSlot(i);
-            if (!(slot instanceof CardHolderSlot)) continue;
-            ((CardHolderSlot) slot).setEnabled(showCardHolderUI);
+            if (slot instanceof CardHolderSlot cardHolderSlot) {
+                cardHolderSlot.setEnabled(showCardHolderUI);
+            }
         }
     }
 

--- a/src/main/java/com/direwolf20/laserio/client/screens/CardItemScreen.java
+++ b/src/main/java/com/direwolf20/laserio/client/screens/CardItemScreen.java
@@ -213,8 +213,9 @@ public class CardItemScreen extends AbstractContainerScreen<CardItemContainer> {
         for (int i = (CardItemContainer.SLOTS + CardItemContainer.FILTERSLOTS); i < (CardItemContainer.SLOTS + CardItemContainer.FILTERSLOTS + CardHolderContainer.SLOTS); i++) {
             if (i >= container.slots.size()) continue;
             Slot slot = container.getSlot(i);
-            if (!(slot instanceof CardHolderSlot)) continue;
-            ((CardHolderSlot) slot).setEnabled(showCardHolderUI);
+            if (slot instanceof CardHolderSlot cardHolderSlot) {
+                cardHolderSlot.setEnabled(showCardHolderUI);
+            }
         }
     }
 
@@ -583,8 +584,9 @@ public class CardItemScreen extends AbstractContainerScreen<CardItemContainer> {
         for (int i = CardItemContainer.SLOTS; i < (CardItemContainer.SLOTS + CardItemContainer.FILTERSLOTS); i++) {
             if (i >= container.slots.size()) continue;
             Slot slot = container.getSlot(i);
-            if (!(slot instanceof FilterBasicSlot)) continue;
-            ((FilterBasicSlot) slot).setEnabled(showFilter);
+            if (slot instanceof FilterBasicSlot filterBasicSlot) {
+                filterBasicSlot.setEnabled(showFilter);
+            }
         }
     }
 

--- a/src/main/java/com/direwolf20/laserio/client/screens/LaserNodeScreen.java
+++ b/src/main/java/com/direwolf20/laserio/client/screens/LaserNodeScreen.java
@@ -163,8 +163,9 @@ public class LaserNodeScreen extends AbstractContainerScreen<LaserNodeContainer>
         for (int i = LaserNodeContainer.CARDSLOTS; i < (LaserNodeContainer.CARDSLOTS + CardHolderContainer.SLOTS); i++) {
             if (i >= container.slots.size()) continue;
             Slot slot = container.getSlot(i);
-            if (!(slot instanceof CardHolderSlot)) continue;
-            ((CardHolderSlot) slot).setEnabled(showCardHolderUI);
+            if (slot instanceof CardHolderSlot cardHolderSlot) {
+                cardHolderSlot.setEnabled(showCardHolderUI);
+            }
         }
     }
 

--- a/src/main/java/com/direwolf20/laserio/common/containers/CardEnergyContainer.java
+++ b/src/main/java/com/direwolf20/laserio/common/containers/CardEnergyContainer.java
@@ -86,6 +86,9 @@ public class CardEnergyContainer extends AbstractContainerMenu {
 
     @Override
     public void clicked(int slotId, int dragType, ClickType clickTypeIn, Player player) {
+        if (clickTypeIn == ClickType.SWAP) {
+            return;
+        }
         if (slotId >= 0) {
             Slot slot = slots.get(slotId);
             ItemStack stackInSlot = slot.getItem();
@@ -115,9 +118,6 @@ public class CardEnergyContainer extends AbstractContainerMenu {
             if (!(cardHolder.getItem() instanceof CardHolder) || !CardHolder.getUUID(cardHolder).equals(cardHolderUUID)) {
                 return false;
             }
-        }
-        if (sourceContainer.equals(BlockPos.ZERO)) {
-            return playerIn.getMainHandItem().equals(cardItem) || playerIn.getOffhandItem().equals(cardItem);
         }
         return true;
     }

--- a/src/main/java/com/direwolf20/laserio/common/containers/CardHolderContainer.java
+++ b/src/main/java/com/direwolf20/laserio/common/containers/CardHolderContainer.java
@@ -46,6 +46,9 @@ public class CardHolderContainer extends AbstractContainerMenu {
 
     @Override
     public void clicked(int slotId, int dragType, ClickType clickTypeIn, Player player) {
+        if (clickTypeIn == ClickType.SWAP) {
+            return;
+        }
         if (slotId >= 0) {
             Slot slot = slots.get(slotId);
             ItemStack stackInSlot = slot.getItem();

--- a/src/main/java/com/direwolf20/laserio/common/containers/CardItemContainer.java
+++ b/src/main/java/com/direwolf20/laserio/common/containers/CardItemContainer.java
@@ -92,7 +92,7 @@ public class CardItemContainer extends AbstractContainerMenu {
 
     @Override
     public void clicked(int slotId, int dragType, ClickType clickTypeIn, Player player) {
-        if (slotId >= SLOTS && slotId < SLOTS + FILTERSLOTS) {
+        if (clickTypeIn == ClickType.SWAP || (slotId >= SLOTS && slotId < SLOTS + FILTERSLOTS)) {
             return;
         }
         if (slotId >= 0) {
@@ -139,9 +139,6 @@ public class CardItemContainer extends AbstractContainerMenu {
             if (!(cardHolder.getItem() instanceof CardHolder) || !CardHolder.getUUID(cardHolder).equals(cardHolderUUID)) {
                 return false;
             }
-        }
-        if (sourceContainer.equals(BlockPos.ZERO)) {
-            return (playerIn.getMainHandItem().equals(cardItem) || playerIn.getOffhandItem().equals(cardItem));
         }
         return true;
     }

--- a/src/main/java/com/direwolf20/laserio/common/containers/CardRedstoneContainer.java
+++ b/src/main/java/com/direwolf20/laserio/common/containers/CardRedstoneContainer.java
@@ -52,6 +52,9 @@ public class CardRedstoneContainer extends AbstractContainerMenu {
 
     @Override
     public void clicked(int slotId, int dragType, ClickType clickTypeIn, Player player) {
+        if (clickTypeIn == ClickType.SWAP) {
+            return;
+        }
         if (slotId >= 0) {
             ItemStack stackInSlot = slots.get(slotId).getItem();
             Item itemInSlot = stackInSlot.getItem();

--- a/src/main/java/com/direwolf20/laserio/common/containers/FilterBasicContainer.java
+++ b/src/main/java/com/direwolf20/laserio/common/containers/FilterBasicContainer.java
@@ -64,6 +64,9 @@ public class FilterBasicContainer extends AbstractContainerMenu {
 
     @Override
     public void clicked(int slotId, int dragType, ClickType clickTypeIn, Player player) {
+        if (clickTypeIn == ClickType.SWAP) {
+            return;
+        }
         if (slotId >= 0) {
             ItemStack stackInSlot = slots.get(slotId).getItem();
             Item itemInSlot = stackInSlot.getItem();

--- a/src/main/java/com/direwolf20/laserio/common/containers/FilterCountContainer.java
+++ b/src/main/java/com/direwolf20/laserio/common/containers/FilterCountContainer.java
@@ -59,6 +59,9 @@ public class FilterCountContainer extends AbstractContainerMenu {
 
     @Override
     public void clicked(int slotId, int dragType, ClickType clickTypeIn, Player player) {
+        if (clickTypeIn == ClickType.SWAP) {
+            return;
+        }
         if (slotId >= 0) {
             ItemStack stackInSlot = slots.get(slotId).getItem();
             Item itemInSlot = stackInSlot.getItem();

--- a/src/main/java/com/direwolf20/laserio/common/containers/FilterNBTContainer.java
+++ b/src/main/java/com/direwolf20/laserio/common/containers/FilterNBTContainer.java
@@ -63,6 +63,9 @@ public class FilterNBTContainer extends AbstractContainerMenu {
 
     @Override
     public void clicked(int slotId, int dragType, ClickType clickTypeIn, Player player) {
+        if (clickTypeIn == ClickType.SWAP) {
+            return;
+        }
         if (slotId >= 0) {
             ItemStack stackInSlot = slots.get(slotId).getItem();
             Item itemInSlot = stackInSlot.getItem();

--- a/src/main/java/com/direwolf20/laserio/common/containers/FilterTagContainer.java
+++ b/src/main/java/com/direwolf20/laserio/common/containers/FilterTagContainer.java
@@ -63,6 +63,9 @@ public class FilterTagContainer extends AbstractContainerMenu {
 
     @Override
     public void clicked(int slotId, int dragType, ClickType clickTypeIn, Player player) {
+        if (clickTypeIn == ClickType.SWAP) {
+            return;
+        }
         if (slotId >= 0) {
             ItemStack stackInSlot = slots.get(slotId).getItem();
             Item itemInSlot = stackInSlot.getItem();

--- a/src/main/java/com/direwolf20/laserio/common/containers/LaserNodeContainer.java
+++ b/src/main/java/com/direwolf20/laserio/common/containers/LaserNodeContainer.java
@@ -68,6 +68,9 @@ public class LaserNodeContainer extends AbstractContainerMenu {
 
     @Override
     public void clicked(int slotId, int dragType, ClickType clickTypeIn, Player player) {
+        if (clickTypeIn == ClickType.SWAP) {
+            return;
+        }
         if (slotId >= 0) {
             Slot slot = slots.get(slotId);
             ItemStack stackInSlot = slot.getItem();


### PR DESCRIPTION
Should cover some edge cases where the player could move using hotkeys and then drop the Card they were configuring (or the Card Holder they were using to configure a Card/Node)