### PR TITLE
Fix shader effects workarounds in case Oculus is loaded

### DIFF
--- a/src/main/java/com/direwolf20/laserio/client/renderer/MyRenderType.java
+++ b/src/main/java/com/direwolf20/laserio/client/renderer/MyRenderType.java
@@ -1,51 +1,59 @@
 package com.direwolf20.laserio.client.renderer;
 
-import com.direwolf20.laserio.client.events.ClientEvents;
 import com.direwolf20.laserio.common.LaserIO;
 import com.mojang.blaze3d.vertex.DefaultVertexFormat;
 import com.mojang.blaze3d.vertex.VertexFormat;
-import net.minecraft.client.renderer.GameRenderer;
-import net.minecraft.client.renderer.RenderStateShard;
 import net.minecraft.client.renderer.RenderType;
 import net.minecraft.resources.ResourceLocation;
 
 public class MyRenderType extends RenderType {
     private static final ResourceLocation SMALL_LASER_BEAM_TEXTURE = new ResourceLocation(LaserIO.MODID, "textures/misc/laser.png");
     private static final ResourceLocation BIG_LASER_BEAM_TEXTURE = new ResourceLocation(LaserIO.MODID, "textures/misc/laser2.png");
-    private static final VertexFormat VERTEX_FORMAT = ClientEvents.IS_OCULUS_LOADED ? DefaultVertexFormat.POSITION_TEX_LIGHTMAP_COLOR : DefaultVertexFormat.POSITION_COLOR_TEX_LIGHTMAP;
-    private static final RenderStateShard.ShaderStateShard POSITION_TEX_LIGHTMAP_COLOR_SHADER = new RenderStateShard.ShaderStateShard(GameRenderer::getPositionTexLightmapColorShader);
-    private static final RenderStateShard.ShaderStateShard SHADER = ClientEvents.IS_OCULUS_LOADED ? POSITION_TEX_LIGHTMAP_COLOR_SHADER : POSITION_COLOR_TEX_LIGHTMAP_SHADER;
 
     //Dummy
     public MyRenderType(String name, VertexFormat format, VertexFormat.Mode p_i225992_3_, int p_i225992_4_, boolean p_i225992_5_, boolean p_i225992_6_, Runnable runnablePre, Runnable runnablePost) {
         super(name, format, p_i225992_3_, p_i225992_4_, p_i225992_5_, p_i225992_6_, runnablePre, runnablePost);
     }
 
-    private static RenderType createRenderType(String name, ResourceLocation texture, RenderStateShard.LayeringStateShard layering, RenderStateShard.WriteMaskStateShard writeMask) {
-        return create(
-                name,
-                VERTEX_FORMAT,
-                VertexFormat.Mode.QUADS,
-                256,
-                false,
-                false,
-                RenderType.CompositeState.builder()
-                        .setTextureState(new TextureStateShard(texture, false, false))
-                        .setShaderState(SHADER)
-                        .setLayeringState(layering)
-                        .setTransparencyState(TRANSLUCENT_TRANSPARENCY)
-                        .setDepthTestState(LEQUAL_DEPTH_TEST)
-                        .setCullState(CULL)
-                        .setLightmapState(NO_LIGHTMAP)
-                        .setWriteMaskState(writeMask)
-                        .createCompositeState(false)
-        );
-    }
-
-    public static final RenderType LASER_MAIN_BEAM = createRenderType("MiningLaserMainBeam", BIG_LASER_BEAM_TEXTURE, NO_LAYERING, COLOR_DEPTH_WRITE);
-    public static final RenderType LASER_MAIN_CORE = createRenderType("MiningLaserCoreBeam", SMALL_LASER_BEAM_TEXTURE, VIEW_OFFSET_Z_LAYERING, COLOR_WRITE);
-    public static final RenderType CONNECTING_LASER = createRenderType("ConnectingLaser", SMALL_LASER_BEAM_TEXTURE, VIEW_OFFSET_Z_LAYERING, COLOR_WRITE);
-
+    public static final RenderType LASER_MAIN_BEAM = create("MiningLaserMainBeam",
+            DefaultVertexFormat.POSITION_COLOR_TEX_LIGHTMAP, VertexFormat.Mode.QUADS, 256, false, false,
+            RenderType.CompositeState.builder()
+                    .setTextureState(new TextureStateShard(BIG_LASER_BEAM_TEXTURE, false, false))
+                    .setShaderState(ShaderStateShard.POSITION_COLOR_TEX_LIGHTMAP_SHADER)
+                    .setLayeringState(NO_LAYERING)
+                    .setTransparencyState(TRANSLUCENT_TRANSPARENCY)
+                    .setDepthTestState(LEQUAL_DEPTH_TEST)
+                    .setCullState(CULL)
+                    .setLightmapState(NO_LIGHTMAP)
+                    .setWriteMaskState(COLOR_DEPTH_WRITE)
+                    .createCompositeState(false)
+    );
+    public static final RenderType LASER_MAIN_CORE = create("MiningLaserCoreBeam",
+            DefaultVertexFormat.POSITION_COLOR_TEX_LIGHTMAP, VertexFormat.Mode.QUADS, 256, false, false,
+            RenderType.CompositeState.builder()
+                    .setTextureState(new TextureStateShard(SMALL_LASER_BEAM_TEXTURE, false, false))
+                    .setShaderState(ShaderStateShard.POSITION_COLOR_TEX_LIGHTMAP_SHADER)
+                    .setLayeringState(VIEW_OFFSET_Z_LAYERING)
+                    .setTransparencyState(TRANSLUCENT_TRANSPARENCY)
+                    .setDepthTestState(LEQUAL_DEPTH_TEST)
+                    .setCullState(CULL)
+                    .setLightmapState(NO_LIGHTMAP)
+                    .setWriteMaskState(COLOR_WRITE)
+                    .createCompositeState(false)
+    );
+    public static final RenderType CONNECTING_LASER = create("ConnectingLaser",
+            DefaultVertexFormat.POSITION_COLOR_TEX_LIGHTMAP, VertexFormat.Mode.QUADS, 256, false, false,
+            RenderType.CompositeState.builder()
+                    .setTextureState(new TextureStateShard(SMALL_LASER_BEAM_TEXTURE, false, false))
+                    .setShaderState(ShaderStateShard.POSITION_COLOR_TEX_LIGHTMAP_SHADER)
+                    .setLayeringState(VIEW_OFFSET_Z_LAYERING)
+                    .setTransparencyState(TRANSLUCENT_TRANSPARENCY)
+                    .setDepthTestState(LEQUAL_DEPTH_TEST)
+                    .setCullState(CULL)
+                    .setLightmapState(NO_LIGHTMAP)
+                    .setWriteMaskState(COLOR_WRITE)
+                    .createCompositeState(false)
+    );
     public static final RenderType BLOCK_OVERLAY = create("MiningLaserBlockOverlay",
             DefaultVertexFormat.POSITION_COLOR, VertexFormat.Mode.QUADS, 256, false, false,
             RenderType.CompositeState.builder()

--- a/src/main/java/com/direwolf20/laserio/client/renderer/RenderUtils.java
+++ b/src/main/java/com/direwolf20/laserio/client/renderer/RenderUtils.java
@@ -125,18 +125,13 @@ public class RenderUtils {
         return adjustedVec;
     }
 
-    public static void addVertexToBuilder(VertexConsumer builder, Matrix4f positionMatrix, Vector3f position,  float r, float g, float b, float alpha, float v1, float v2) {
-        builder.vertex(positionMatrix, position.x(), position.y(), position.z());
-        if (!ClientEvents.IS_OCULUS_LOADED) {
-            builder.color(r, g, b, alpha);
-        }
-        builder.uv(v1, v2)
+    public static void addVertexToBuilder(VertexConsumer builder, Matrix4f positionMatrix, Vector3f position, float r, float g, float b, float alpha, float v1, float v2) {
+        builder.vertex(positionMatrix, position.x(), position.y(), position.z())
+                .color(r, g, b, alpha)
+                .uv(v1, v2)
                 .overlayCoords(OverlayTexture.NO_OVERLAY)
-                .uv2(15728880);
-        if (ClientEvents.IS_OCULUS_LOADED) {
-            builder.color(r, g, b, alpha);
-        }
-        builder.endVertex();
+                .uv2(15728880)
+                .endVertex();
     }
 
     public static void drawLaser(VertexConsumer builder, Matrix4f positionMatrix, Vector3f from, Vector3f to, float r, float g, float b, float alpha, float thickness, double v1, double v2, BlockEntity be) {


### PR DESCRIPTION
Fixes the workarounds added in #90 (now the shader effects render correctly even with shaders, before this fix they worked with Oculus only if no shaders were enabled).
Fixes also all the upstream duplicates of #61: https://github.com/Direwolf20-MC/LaserIO/issues/184, https://github.com/Direwolf20-MC/LaserIO/issues/207, https://github.com/Direwolf20-MC/LaserIO/issues/217, https://github.com/Direwolf20-MC/LaserIO/issues/224, https://github.com/Direwolf20-MC/LaserIO/issues/305