### PR TITLE
Unify scroll wheel behaviour across Card screens

### DIFF
--- a/src/main/java/com/direwolf20/laserio/client/screens/CardItemScreen.java
+++ b/src/main/java/com/direwolf20/laserio/client/screens/CardItemScreen.java
@@ -708,7 +708,7 @@ public class CardItemScreen extends AbstractContainerScreen<CardItemContainer> {
         if (Screen.hasControlDown()) amt *= 64;
         int newCount = slotStack.getCount() + amt;
         if (newCount > 4096) newCount = 4096;
-        if (newCount < 0) newCount = (isScrollWheel) ? 1 : 0;
+        if (newCount <= 0) newCount = (isScrollWheel) ? 1 : 0;
 
         PacketHandler.sendToServer(new PacketGhostSlot(hoveredSlot.index, slotStack, newCount));
         return true;


### PR DESCRIPTION
Scrolling the mouse wheel over a Counting Filter slot in an Item Card no longer removes the filtered item; it now remains with a minimum quantity of 1.
This mirrors the behaviour of Counting Filters in Fluid and Chemical Cards, where the filtered fluid/chemical stays at 1 mb