### PR TITLE
Add button to clear card data in card holder

### DIFF
--- a/src/generated/resources/assets/laserio/lang/en_us.json
+++ b/src/generated/resources/assets/laserio/lang/en_us.json
@@ -90,6 +90,7 @@
   "screen.laserio.apply": "Apply",
   "screen.laserio.blue": "Blue",
   "screen.laserio.channel": "Channel: ",
+  "screen.laserio.clearcards": "Clear Card Data",
   "screen.laserio.comparenbt": "NBT",
   "screen.laserio.default": "Default",
   "screen.laserio.denylist": "Deny",

--- a/src/main/java/com/direwolf20/laserio/client/screens/CardHolderScreen.java
+++ b/src/main/java/com/direwolf20/laserio/client/screens/CardHolderScreen.java
@@ -1,22 +1,29 @@
 package com.direwolf20.laserio.client.screens;
 
+import com.direwolf20.laserio.client.screens.widgets.IconButton;
 import com.direwolf20.laserio.common.LaserIO;
 import com.direwolf20.laserio.common.containers.CardHolderContainer;
 import com.direwolf20.laserio.common.containers.customslot.CardHolderSlot;
+import com.direwolf20.laserio.common.items.cards.BaseCard;
 import com.direwolf20.laserio.common.items.filters.BaseFilter;
 import com.direwolf20.laserio.common.network.PacketHandler;
+import com.direwolf20.laserio.common.network.packets.PacketClearCards;
 import com.direwolf20.laserio.common.network.packets.PacketOpenCard;
 import com.direwolf20.laserio.common.network.packets.PacketOpenFilter;
+import com.direwolf20.laserio.util.MiscTools;
 import com.mojang.blaze3d.systems.RenderSystem;
 import net.minecraft.client.gui.GuiGraphics;
+import net.minecraft.client.gui.components.Button;
 import net.minecraft.client.gui.screens.inventory.AbstractContainerScreen;
 import net.minecraft.core.BlockPos;
 import net.minecraft.network.chat.Component;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.entity.player.Inventory;
+import net.minecraft.world.inventory.Slot;
 
 public class CardHolderScreen extends AbstractContainerScreen<CardHolderContainer> {
     private static final ResourceLocation GUI = new ResourceLocation(LaserIO.MODID, "textures/gui/cardholder.png");
+    private Button clearButton;
 
     public CardHolderScreen(CardHolderContainer container, Inventory inv, Component name) {
         super(container, inv, name);
@@ -24,10 +31,26 @@ public class CardHolderScreen extends AbstractContainerScreen<CardHolderContaine
     }
 
     @Override
+    public void init() {
+        super.init();
+
+        ResourceLocation texture = new ResourceLocation(LaserIO.MODID, "textures/gui/buttons/matchnbtfalse.png");
+        clearButton = new IconButton(this.leftPos + 155, this.topPos + 15, 16, 16, texture, (button) -> {
+            PacketHandler.sendToServer(new PacketClearCards());
+        });
+
+        addRenderableWidget(clearButton);
+    }
+
+    @Override
     public void render(GuiGraphics guiGraphics, int mouseX, int mouseY, float partialTicks) {
         this.renderBackground(guiGraphics);
         super.render(guiGraphics, mouseX, mouseY, partialTicks);
         this.renderTooltip(guiGraphics, mouseX, mouseY);
+
+        if (MiscTools.inBounds(clearButton.getX(), clearButton.getY(), clearButton.getWidth(), clearButton.getHeight(), mouseX, mouseY)) {
+            guiGraphics.renderTooltip(font, Component.translatable("screen.laserio.clearcards"), mouseX, mouseY);
+        }
     }
 
     @Override

--- a/src/main/java/com/direwolf20/laserio/common/containers/CardHolderContainer.java
+++ b/src/main/java/com/direwolf20/laserio/common/containers/CardHolderContainer.java
@@ -2,8 +2,11 @@ package com.direwolf20.laserio.common.containers;
 
 import com.direwolf20.laserio.common.containers.customslot.CardHolderSlot;
 import com.direwolf20.laserio.common.items.CardHolder;
+import com.direwolf20.laserio.common.items.cards.BaseCard;
+import com.direwolf20.laserio.common.items.filters.BaseFilter;
 import com.direwolf20.laserio.setup.Registration;
 import net.minecraft.core.BlockPos;
+import net.minecraft.nbt.CompoundTag;
 import net.minecraft.network.FriendlyByteBuf;
 import net.minecraft.world.entity.player.Inventory;
 import net.minecraft.world.entity.player.Player;
@@ -15,7 +18,8 @@ import net.minecraftforge.items.IItemHandler;
 import net.minecraftforge.items.ItemStackHandler;
 import net.minecraftforge.items.SlotItemHandler;
 import net.minecraftforge.items.wrapper.InvWrapper;
-
+import java.util.ArrayList;
+import java.util.List;
 import java.util.UUID;
 
 public class CardHolderContainer extends AbstractContainerMenu {
@@ -193,6 +197,54 @@ public class CardHolderContainer extends AbstractContainerMenu {
             }
         }
         return itemStack;
+    }
+
+    public void clearCards(Player sender) {
+        List<ItemStack> extraItems = new ArrayList<>();
+        for (int i = 0; i < SLOTS; i++) {
+            var stack = this.slots.get(i).getItem();
+            var item = stack.getItem();
+            if (item instanceof BaseFilter) {
+                stack.setTag(new CompoundTag());
+            } else if (item instanceof BaseCard card) {
+                List<ItemStack> cardItems = card.getContainerItems(stack);
+                for (var innerItem : cardItems) {
+                    if (!innerItem.isEmpty()) {
+                        // x cards each with y filters
+                        // so turn it into x*y filters
+                        innerItem.setCount(stack.getCount() * innerItem.getCount());
+                        extraItems.add(innerItem);
+                    }
+                }
+                stack.setTag(new CompoundTag());
+            }
+        }
+
+        // bunch up equal cards
+        for (int i = SLOTS - 1; i >= 0; i--) {
+            var stack = this.slots.get(i).getItem();
+            var item = stack.getItem();
+            if (item instanceof BaseFilter || item instanceof BaseCard) {
+                for (int j = 0; j < i; j++) {
+                    var otherSlot = this.slots.get(j);
+                    var otherStack = otherSlot.getItem();
+                    if (ItemStack.isSameItemSameTags(stack, otherStack)) {
+                        otherSlot.safeInsert(stack);
+                        if (stack.isEmpty()) break;
+                    }
+                }
+            }
+        }
+
+        for (var stack : extraItems) {
+            for (var slot : slots) {
+                slot.safeInsert(stack);
+                if (stack.isEmpty()) break;
+            }
+            if (!stack.isEmpty()) {
+                sender.drop(stack, false);
+            }
+        }
     }
 
     private int addSlotRange(IItemHandler handler, int index, int x, int y, int amount, int dx) {

--- a/src/main/java/com/direwolf20/laserio/common/network/PacketHandler.java
+++ b/src/main/java/com/direwolf20/laserio/common/network/PacketHandler.java
@@ -2,6 +2,7 @@ package com.direwolf20.laserio.common.network;
 
 import com.direwolf20.laserio.common.LaserIO;
 import com.direwolf20.laserio.common.network.packets.PacketChangeColor;
+import com.direwolf20.laserio.common.network.packets.PacketClearCards;
 import com.direwolf20.laserio.common.network.packets.PacketCopyPasteCard;
 import com.direwolf20.laserio.common.network.packets.PacketGhostSlot;
 import com.direwolf20.laserio.common.network.packets.PacketNodeParticles;
@@ -58,6 +59,7 @@ public class PacketHandler {
         //Client Side
         HANDLER.registerMessage(id++, PacketNodeParticles.class, PacketNodeParticles::encode, PacketNodeParticles::decode, PacketNodeParticles.Handler::handle);
         HANDLER.registerMessage(id++, PacketNodeParticlesFluid.class, PacketNodeParticlesFluid::encode, PacketNodeParticlesFluid::decode, PacketNodeParticlesFluid.Handler::handle);
+        HANDLER.registerMessage(id++, PacketClearCards.class, PacketClearCards::encode, PacketClearCards::decode, PacketClearCards.Handler::handle);
 
         //Mekanism packets
         if (ModIntegration.MEKANISM.isLoaded()) {

--- a/src/main/java/com/direwolf20/laserio/common/network/packets/PacketClearCards.java
+++ b/src/main/java/com/direwolf20/laserio/common/network/packets/PacketClearCards.java
@@ -1,0 +1,41 @@
+package com.direwolf20.laserio.common.network.packets;
+
+import com.direwolf20.laserio.common.containers.CardHolderContainer;
+import net.minecraft.network.FriendlyByteBuf;
+import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.world.inventory.AbstractContainerMenu;
+import net.minecraftforge.network.NetworkEvent;
+
+import java.util.function.Supplier;
+
+public class PacketClearCards {
+    public PacketClearCards() {
+    }
+
+    public static void encode(PacketClearCards msg, FriendlyByteBuf buffer) {
+    }
+
+    public static PacketClearCards decode(FriendlyByteBuf buffer) {
+        return new PacketClearCards();
+    }
+
+    public static class Handler {
+        public static void handle(PacketClearCards msg, Supplier<NetworkEvent.Context> ctx) {
+            ctx.get().enqueueWork(() -> {
+                ServerPlayer sender = ctx.get().getSender();
+                if (sender == null) {
+                    return;
+                }
+                AbstractContainerMenu container = sender.containerMenu;
+                if (container == null) {
+                    return;
+                }
+                if (container instanceof CardHolderContainer cardContainer) {
+                    cardContainer.clearCards(sender);
+                }
+            });
+
+            ctx.get().setPacketHandled(true);
+        }
+    }
+}

--- a/src/main/java/com/direwolf20/laserio/datagen/LaserIOLanguage.java
+++ b/src/main/java/com/direwolf20/laserio/datagen/LaserIOLanguage.java
@@ -103,6 +103,8 @@ public class LaserIOLanguage extends LanguageProvider {
         add("screen.laserio.nbttrue", "Match NBT");
         add("screen.laserio.nbtfalse", "Ignore NBT");
 
+        add("screen.laserio.clearcards", "Clear Card Data");
+
         //General tooltips
         add("laserio.tooltip.item.show_details", "Hold shift to show details");
         add("laserio.tooltip.item.show_settings.shift_key", "Hold shift to show settings");


### PR DESCRIPTION
Adds a new button to the card holder allowing you to quickly reset all the cards stored in the holder.

<img  height="200" alt="image" src="https://github.com/user-attachments/assets/2124114b-c564-4b6e-90e8-1859cba9b75f" />
<img  height="200" alt="image" src="https://github.com/user-attachments/assets/bfa1495d-3955-407c-ac7a-ddb7ead05d6d" />

## Important notes:
* Similar to putting the cards in a crafting slot, it does not immediately reset filters, meaning you'd have to click the button again to reset them
* Can change texture or tooltip text if needed
* It has code for clumping similar cards for convenience, kind of like sorting the items